### PR TITLE
Fix NOAA when closest stations is the reference station

### DIFF
--- a/src/sources/noaa.js
+++ b/src/sources/noaa.js
@@ -76,7 +76,7 @@ class NoaaProvider {
       begin_date: moment(date).format("YYYYMMDD"),
       end_date: moment(date).add(7, "days").format("YYYYMMDD"),
       datum,
-      station: station.reference_id,
+      station: station.id,
       time_zone: "gmt",
       units: "metric",
       interval: "hilo",
@@ -96,7 +96,7 @@ class NoaaProvider {
 
       let tides = {
         name: station.name,
-        id: station.reference_id,
+        id: station.id,
         position: {
           latitude: station.lat,
           longitude: station.lng,
@@ -112,7 +112,8 @@ class NoaaProvider {
 
       return tides;
     } catch (err) {
-      reportError(error);
+      this.app.setPluginError("Failed to fetch NOAA tides: " + err.message);
+      this.app.error(err);
       res.status(404).send("error");
     }
   }


### PR DESCRIPTION
The side-effect of this is that is will use "Subordinate" tide stations for everyone else. I need to do more research on this to determine if this should just filter out subordinate stations, or maybe have a setting to use reference vs subordinate.

https://tidesandcurrents.noaa.gov/PageHelp.html

cc https://discord.com/channels/1170433917761892493/1354169784819781802