### PR TITLE
Use browser locale for localization of time/units

### DIFF
--- a/app/components/TideChart.tsx
+++ b/app/components/TideChart.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
 import { TideExtreme } from "../hooks/useTideData";
-import moment from "moment";
 import { useContainerDimensions } from "../hooks/useContainerDimensions";
 
 type TideChartProps = {
@@ -12,7 +11,6 @@ type TideChartProps = {
   marginBottom?: number;
   marginLeft?: number;
   units?: "m" | "ft";
-  timeFormat?: string;
   data: TideExtreme[];
 };
 
@@ -23,7 +21,6 @@ export function TideChart({
   marginBottom = 30,
   marginLeft = 6,
   units = "m",
-  timeFormat = "HH:mm",
 }: TideChartProps) {
   const container = useRef<HTMLDivElement>(null);
   const now = useRef<SVGLineElement>(null);
@@ -47,7 +44,9 @@ export function TideChart({
   }
 
   function displayTime(value: string) {
-    return moment(value).format(timeFormat);
+    return new Intl.DateTimeFormat(navigator.language, {
+      timeStyle: "short",
+    }).format(new Date(value));
   }
 
   useEffect(() => {

--- a/app/views/TidesView.tsx
+++ b/app/views/TidesView.tsx
@@ -23,8 +23,7 @@ export function TidesView() {
       </header >
       {
         data?.extremes ?
-          <TideChart data={data?.extremes ?? []
-          } units="ft" timeFormat="h:mm a" /> :
+          <TideChart data={data.extremes} units="ft" /> :
           <LoadingTidesView />
       }
     </>

--- a/app/views/TidesView.tsx
+++ b/app/views/TidesView.tsx
@@ -4,6 +4,7 @@ import { TideChart } from '../components/TideChart'
 
 export function TidesView() {
   const data = useTideData();
+  const units = navigator.language === 'en-US' ? 'ft' : 'm';
 
   return (
     <>
@@ -23,7 +24,7 @@ export function TidesView() {
       </header >
       {
         data?.extremes ?
-          <TideChart data={data.extremes} units="ft" /> :
+          <TideChart data={data.extremes} units={units} /> :
           <LoadingTidesView />
       }
     </>


### PR DESCRIPTION
This uses the browser's locale to format times (using [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat)), and uses the current locale to determine meters/feet (`en-US` uses ft, everywhere else uses m for now).

Fixes #9 