### PR TITLE
Small delay before performing first update / wait for valid position …

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,8 +166,11 @@ export = function (app: SignalKApp): Plugin {
       }
     }
 
-    // Perform initial update on startup
-    performUpdate();
+    // Perform initial update on startup after short delay to allow gnss position to be populated
+    delay(4000).then(() => { performUpdate() });
+  }
+  function delay(time) {
+    return new Promise((resolve) => setTimeout(resolve, time));
   }
 
   return plugin;


### PR DESCRIPTION
…data

GNSS position values may not be populated at startup of SK.  

Addresses:  https://github.com/bkeepers/signalk-tides/issues/8