### PR TITLE
Calculate and set environment.tide.heightNow

### DIFF
--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -1,0 +1,30 @@
+import type { TideExtreme } from './types';
+
+/** Given a list of tide extremes, estimate the height at a specific time. */
+export function approximateTideHeightAt(extremes: TideExtreme[], time: Date): number | null {
+  const sorted = extremes.slice().sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+  const prev = sorted.filter(h => new Date(h.time) <= time).at(-1);
+  const next = sorted.filter(h => new Date(h.time) >= time).at(0);
+
+  if (!prev) throw new Error("Missing height data before " + time.toISOString());
+  if (!next) throw new Error("Missing height data after " + time.toISOString());
+
+  const progress = (time.getTime() - new Date(prev.time).getTime()) /
+    (new Date(next.time).getTime() - new Date(prev.time).getTime());
+
+  const value = interpolate(prev.value, next.value, easeSine(progress));
+
+  return parseFloat(value.toFixed(3));
+}
+
+/** Interpolate between two values using the given progress (0-1). */
+function interpolate(start: number, end: number, progress: number) {
+  return start + (end - start) * progress;
+}
+
+function easeSine(progress: number) {
+  // Map progress [0..1] to angle [0..π]
+  const angle = progress * Math.PI;
+  // Use sine to ease in/out
+  return (1 - Math.cos(angle)) / 2;
+}


### PR DESCRIPTION
This adds `environment.tide.heightNow`, updated every minute. The height is currently just a calculated approximation from high/low extremes using a sine curve.

I have code in progress to fetch intervals from the various sources (NOAA, stormglass, worldtides), but got [nerd sniped](https://xkcd.com/356/) and started looking into doing all the tide calculations internally (#16) instead of depending on 3rd party services. Either way, I'll work on that in a separate PR. 

Fixes https://github.com/bkeepers/signalk-tides/issues/14