### PR TITLE
Issue 31, ts issues, Offline mode, datum changes, etc.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@
 /*config.{mjs,js,ts,mts}
 /test
 /index.html
+*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] - Custom Fork
+
+This fork adds significant enhancements for offline operation and international waters navigation.
+
+### Added
+
+#### Offline Harmonic Prediction
+- **Full offline mode** using NOAA harmonic constituents for accurate tide predictions without internet
+- **Automatic harmonics cache** downloads stations within 500nm radius on startup and quarterly
+- **Smart radius expansion** up to 1000nm if fewer than 2 stations found
+- **Bundled harmonics data** for Fiji region (customizable with extraction tool)
+- **Automatic fallback** to offline mode when online providers fail
+- **MSL to MLLW datum conversion** using official NOAA datum offsets
+
+#### Tidal Datum Support
+- **Standardized on MLLW/CD datum** across all sources for marine navigation
+- All tide heights now positive values (suitable for chart datum navigation)
+- Automatic datum conversion where needed:
+  - **NOAA**: Native MLLW datum (US standard)
+  - **WorldTides**: Chart Datum (CD), equivalent to LAT
+  - **StormGlass**: Requests MLLW datum from API
+  - **Offline**: MSL with automatic MLLW conversion using NOAA datum offsets
+
+#### Station Management
+- **Smart station selection** prevents frequent switching between nearby tide stations
+- **Configurable distance threshold** (default: 10km) for station switching
+- **Position caching** maintains predictions when navigation.position temporarily unavailable
+
+### Changed
+
+- **Simplified configuration** - removed datum selection option (all sources now provide MLLW/CD)
+- **Enhanced StormGlass integration** - requests MLLW datum, logs offset for debugging
+- **Improved WorldTides** - handles missing station names gracefully
+
+### Fixed
+
+- **StormGlass datum parameter** - properly requests MLLW datum from API
+- **WorldTides station names** - handles undefined station field (shows atlas name instead)
+- **TypeScript errors** - fixed type definitions for StormGlass metadata (datum, offset fields)
+
+### Documentation
+
+- Added comprehensive datum explanation for all sources
+- Added data quality warning for StormGlass UHSLC stations in Pacific
+- Documented offline mode features and harmonics cache behavior
+- Added recommendations for international waters (WorldTides or Offline)
+
+### Technical Improvements
+
+- Created `datum.ts` module for datum conversion utilities
+- Created `harmonics-cache.ts` for automatic NOAA harmonics downloads
+- Enhanced type safety with proper datum metadata in forecast results
+- Removed unnecessary datum conversion code (all sources now MLLW/CD)
+
+---
+
+## [1.4.0] - 2025-09-15 (Upstream)
+
+Based on [bkeepers/signalk-tides](https://github.com/bkeepers/signalk-tides)
+
+### Features from Upstream
+- NOAA tide predictions (US waters)
+- WorldTides API support (global, requires API key)
+- StormGlass.io API support (global, requires API key)
+- REST API resource for tide predictions
+- SignalK delta updates for tide data
+- Configurable update frequency
+- Position caching for offline resilience
+
+---
+
+## Fork Information
+
+This is a custom fork of [signalk-tides](https://github.com/bkeepers/signalk-tides) v1.4.0, which itself is a fork of the unmaintained [signalk-tides-api](https://github.com/joabakk/signalk-tides-api).
+
+**Primary enhancements:**
+1. Full offline capability with NOAA harmonic predictions
+2. Automatic harmonics cache management
+3. Standardized MLLW/Chart Datum across all sources
+4. Enhanced data quality awareness and debugging
+
+**Credits:**
+- Original: @joabakk and @sbender9
+- Upstream fork: @bkeepers
+- Offline & datum enhancements: Custom fork

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # signalk-tides
 
-A SignalK plugin that provides tidal predictions for the vessel's position from various online sources.
+A SignalK plugin that provides tidal predictions for the vessel's position from various online sources and offline harmonic prediction.
 
 ## Installation
 
@@ -206,9 +206,33 @@ $ curl http://localhost:3000/signalk/v2/api/resources/tides
 
 ## Sources
 
-- [NOAA](https://tidesandcurrents.noaa.gov/web_services_info.html) (US only)
-- [WorldTides API](https://www.worldtides.info/) (requires an API key)
-- [StormGlass.io](https://stormglass.io/) (requires an API key)
+- **[NOAA](https://tidesandcurrents.noaa.gov/web_services_info.html)** - US waters only, uses MLLW datum, highly accurate
+- **[WorldTides API](https://www.worldtides.info/)** - Global coverage (requires API key), uses Chart Datum (CD/LAT), recommended for international waters
+- **[StormGlass.io](https://stormglass.io/)** - Global coverage (requires API key), supports MSL and MLLW datums
+  - ⚠️ **Note:** Data quality may vary by region, particularly for UHSLC stations in the Pacific. Consider using WorldTides or Offline mode for critical navigation.
+- **Offline** - Harmonic prediction using NOAA harmonic constituents (no internet required), uses MSL datum with automatic MLLW conversion
+
+## Features
+
+### Offline Mode
+- Uses real NOAA harmonic constituents for accurate offline predictions
+- Automatic harmonics cache download (500nm radius, quarterly updates)
+- Fallback to offline when online providers fail
+- Bundled harmonics for Fiji region (can be customized with extraction tool)
+
+### Tidal Datums
+All sources provide tide heights referenced to **MLLW** (Mean Lower Low Water) or equivalent Chart Datum (CD/LAT):
+- **NOAA**: Native MLLW datum (US standard)
+- **WorldTides**: Chart Datum (CD), equivalent to LAT (Lowest Astronomical Tide)
+- **StormGlass**: Requests MLLW datum from API
+- **Offline**: MSL with automatic conversion to MLLW using NOAA datum offsets
+
+This ensures all tide heights are positive values suitable for marine navigation.
+
+### Smart Station Selection
+- Prevents frequent switching between nearby tide stations
+- Configurable distance threshold (default: 10km)
+- Maintains consistent predictions during vessel movement
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@neaps/tide-predictor": "^0.1.1",
     "@react-hook/resize-observer": "^2.0.2",
     "@signalk/server-api": "^2.0",
     "geolib": "^3.3.4",

--- a/src/data/noaa-harmonics.json
+++ b/src/data/noaa-harmonics.json
@@ -1,0 +1,65 @@
+{
+  "version": "noaa-2025-11-28",
+  "info": "NOAA CO-OPS harmonic constituents within 200nm of -17.68°, 177.38°. Contains 1 stations with 8 primary tidal constituents (M2, S2, N2, K2, K1, O1, P1, Q1) for offline tide prediction.",
+  "source": "NOAA Center for Operational Oceanographic Products and Services",
+  "url": "https://tidesandcurrents.noaa.gov/",
+  "extracted": "2025-11-28T22:34:31.572Z",
+  "center": {
+    "latitude": -17.68,
+    "longitude": 177.38
+  },
+  "radiusNM": 200,
+  "stations": [
+    {
+      "id": "1910000",
+      "name": "SUVA, SUVA HARBOR",
+      "lat": -18.1333,
+      "lon": 178.425,
+      "timezone": "NZST",
+      "country": "Fiji",
+      "offset": 0.6560000000000006,
+      "constituents": [
+        {
+          "name": "K1",
+          "amplitude": 0.094,
+          "phase": 57.5
+        },
+        {
+          "name": "K2",
+          "amplitude": 0.027,
+          "phase": 205.3
+        },
+        {
+          "name": "M2",
+          "amplitude": 0.565,
+          "phase": 199.5
+        },
+        {
+          "name": "N2",
+          "amplitude": 0.13,
+          "phase": 172.9
+        },
+        {
+          "name": "O1",
+          "amplitude": 0.046,
+          "phase": 43.2
+        },
+        {
+          "name": "P1",
+          "amplitude": 0.028,
+          "phase": 49.6
+        },
+        {
+          "name": "Q1",
+          "amplitude": 0.007,
+          "phase": 25.7
+        },
+        {
+          "name": "S2",
+          "amplitude": 0.091,
+          "phase": 214.6
+        }
+      ]
+    }
+  ]
+}

--- a/src/data/sample-harmonics.json
+++ b/src/data/sample-harmonics.json
@@ -1,0 +1,60 @@
+{
+  "version": "2024-phase1-sample",
+  "info": "Sample harmonic constituents for Pacific stations. Phase 2 will include comprehensive global coverage from NOAA.",
+  "stations": [
+    {
+      "id": "fiji-lautoka",
+      "name": "Lautoka (Sample)",
+      "lat": -17.6057,
+      "lon": 177.4501,
+      "timezone": "Pacific/Fiji",
+      "country": "Fiji",
+      "constituents": [
+        {"name": "M2", "amplitude": 0.502, "phase": 98.7},
+        {"name": "S2", "amplitude": 0.175, "phase": 129.3},
+        {"name": "N2", "amplitude": 0.112, "phase": 84.2},
+        {"name": "K2", "amplitude": 0.048, "phase": 131.1},
+        {"name": "K1", "amplitude": 0.312, "phase": 271.5},
+        {"name": "O1", "amplitude": 0.198, "phase": 256.8},
+        {"name": "P1", "amplitude": 0.101, "phase": 269.2},
+        {"name": "Q1", "amplitude": 0.038, "phase": 251.4}
+      ]
+    },
+    {
+      "id": "fiji-suva",
+      "name": "Suva Harbor (Sample)",
+      "lat": -18.1333,
+      "lon": 178.4333,
+      "timezone": "Pacific/Fiji",
+      "country": "Fiji",
+      "constituents": [
+        {"name": "M2", "amplitude": 0.573, "phase": 102.4},
+        {"name": "S2", "amplitude": 0.184, "phase": 134.1},
+        {"name": "N2", "amplitude": 0.128, "phase": 88.9},
+        {"name": "K2", "amplitude": 0.051, "phase": 135.8},
+        {"name": "K1", "amplitude": 0.328, "phase": 275.2},
+        {"name": "O1", "amplitude": 0.207, "phase": 260.5},
+        {"name": "P1", "amplitude": 0.106, "phase": 273.1},
+        {"name": "Q1", "amplitude": 0.041, "phase": 255.3}
+      ]
+    },
+    {
+      "id": "pacific-generic",
+      "name": "Pacific Generic Station (Sample)",
+      "lat": 0,
+      "lon": 180,
+      "timezone": "UTC",
+      "country": "Pacific Ocean",
+      "constituents": [
+        {"name": "M2", "amplitude": 0.500, "phase": 100.0},
+        {"name": "S2", "amplitude": 0.180, "phase": 130.0},
+        {"name": "N2", "amplitude": 0.120, "phase": 85.0},
+        {"name": "K2", "amplitude": 0.050, "phase": 132.0},
+        {"name": "K1", "amplitude": 0.320, "phase": 270.0},
+        {"name": "O1", "amplitude": 0.200, "phase": 255.0},
+        {"name": "P1", "amplitude": 0.100, "phase": 268.0},
+        {"name": "Q1", "amplitude": 0.040, "phase": 250.0}
+      ]
+    }
+  ]
+}

--- a/src/datum.ts
+++ b/src/datum.ts
@@ -1,0 +1,71 @@
+/**
+ * Tidal Datum Conversions
+ *
+ * Handles conversion between different tidal datums:
+ * - MSL (Mean Sea Level): Average sea level, can have negative tide heights
+ * - MLLW (Mean Lower Low Water): Average of lower low waters, typically all positive
+ *
+ * Note: We use MLLW offset data from providers to convert between datums.
+ */
+
+import type { TideForecastResult } from './types.js';
+
+export interface DatumInfo {
+  sourceDatum: 'MSL' | 'MLLW';
+  mllwToMslOffset: number;  // Offset in meters to convert MLLW -> MSL
+}
+
+/**
+ * Convert tide forecast to target datum
+ */
+export function convertDatum(
+  forecast: TideForecastResult,
+  datumInfo: DatumInfo,
+  targetDatum: 'MSL' | 'MLLW'
+): TideForecastResult {
+  const { sourceDatum, mllwToMslOffset } = datumInfo;
+
+  // If source and target are the same, no conversion needed
+  if (sourceDatum === targetDatum) {
+    return forecast;
+  }
+
+  // Calculate conversion offset
+  let offset = 0;
+  if (sourceDatum === 'MSL' && targetDatum === 'MLLW') {
+    // MSL -> MLLW: subtract the offset (shift down)
+    offset = -mllwToMslOffset;
+  } else if (sourceDatum === 'MLLW' && targetDatum === 'MSL') {
+    // MLLW -> MSL: add the offset (shift up)
+    offset = mllwToMslOffset;
+  }
+
+  // Apply offset to all extremes
+  return {
+    ...forecast,
+    extremes: forecast.extremes.map(extreme => ({
+      ...extreme,
+      value: extreme.value + offset
+    }))
+  };
+}
+
+/**
+ * Estimate MLLW offset from tide data
+ * Used when provider doesn't supply datum information
+ */
+export function estimateMllwOffset(forecast: TideForecastResult): number {
+  // Find the lowest low tide value
+  const lows = forecast.extremes.filter(e => e.type === 'Low');
+  if (lows.length === 0) return 0;
+
+  const lowestLow = Math.min(...lows.map(e => e.value));
+
+  // MLLW should make the lowest low close to 0
+  // If we're in MSL and lowest low is negative, the offset is approximately |lowestLow|
+  if (lowestLow < 0) {
+    return Math.abs(lowestLow) + 0.2; // Add small margin for safety
+  }
+
+  return 0;
+}

--- a/src/harmonics-cache.ts
+++ b/src/harmonics-cache.ts
@@ -1,0 +1,388 @@
+/**
+ * Harmonics Cache Manager
+ *
+ * Manages persistent caching of NOAA harmonic constituents data.
+ * Downloads regional data based on vessel position and caches to disk.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { getDistance } from 'geolib';
+import type { SignalKApp } from './types.js';
+
+const NOAA_BASE_URL = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi';
+const PRIMARY_CONSTITUENTS = ['M2', 'S2', 'N2', 'K2', 'K1', 'O1', 'P1', 'Q1'];
+
+interface Position {
+  latitude: number;
+  longitude: number;
+}
+
+interface HarmonicConstituent {
+  name: string;
+  amplitude: number;
+  phase: number;
+}
+
+interface HarmonicStation {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  timezone: string;
+  country: string;
+  offset: number;
+  constituents: HarmonicConstituent[];
+}
+
+interface HarmonicsDatabase {
+  version: string;
+  info: string;
+  source: string;
+  url: string;
+  extracted: string;
+  center: Position;
+  radiusNM: number;
+  stations: HarmonicStation[];
+}
+
+interface CacheMetadata {
+  lastUpdate: string;
+  center: Position;
+  radiusNM: number;
+  stationCount: number;
+  noaaVersion: string;
+}
+
+export interface HarmonicsCacheConfig {
+  autoDownloadRadius: number;  // Default: 500nm
+  updateFrequency: 'manual' | 'quarterly' | 'semiannual' | 'annual';  // Default: quarterly
+  minStations: number;  // Default: 2
+  expandRadiusIfNeeded: boolean;  // Default: true
+  maxRadius: number;  // Default: 1000nm
+}
+
+export class HarmonicsCache {
+  private app: SignalKApp;
+  private config: HarmonicsCacheConfig;
+  private cacheDir: string;
+  private cacheFile: string;
+  private metadataFile: string;
+  private backupFile: string;
+
+  constructor(app: SignalKApp, dataDir: string, config: HarmonicsCacheConfig) {
+    this.app = app;
+    this.config = config;
+
+    // Set up cache directory
+    this.cacheDir = join(dataDir, 'harmonics-cache');
+    this.cacheFile = join(this.cacheDir, 'harmonics.json');
+    this.metadataFile = join(this.cacheDir, 'metadata.json');
+    this.backupFile = join(this.cacheDir, 'harmonics-backup.json');
+
+    // Ensure cache directory exists
+    if (!existsSync(this.cacheDir)) {
+      mkdirSync(this.cacheDir, { recursive: true });
+      this.app.debug(`Created harmonics cache directory: ${this.cacheDir}`);
+    }
+  }
+
+  /**
+   * Load cached harmonics data
+   */
+  loadCache(): HarmonicsDatabase | null {
+    try {
+      if (existsSync(this.cacheFile)) {
+        const data = readFileSync(this.cacheFile, 'utf-8');
+        const database = JSON.parse(data) as HarmonicsDatabase;
+        this.app.debug(`Loaded ${database.stations.length} stations from cache`);
+        return database;
+      }
+    } catch (error) {
+      this.app.error(`Failed to load harmonics cache: ${error}`);
+    }
+    return null;
+  }
+
+  /**
+   * Load cache metadata
+   */
+  private loadMetadata(): CacheMetadata | null {
+    try {
+      if (existsSync(this.metadataFile)) {
+        const data = readFileSync(this.metadataFile, 'utf-8');
+        return JSON.parse(data) as CacheMetadata;
+      }
+    } catch (error) {
+      this.app.error(`Failed to load cache metadata: ${error}`);
+    }
+    return null;
+  }
+
+  /**
+   * Save harmonics data to cache
+   */
+  private saveCache(database: HarmonicsDatabase): void {
+    try {
+      // Backup existing cache
+      if (existsSync(this.cacheFile)) {
+        const backup = readFileSync(this.cacheFile, 'utf-8');
+        writeFileSync(this.backupFile, backup);
+      }
+
+      // Write new cache
+      writeFileSync(this.cacheFile, JSON.stringify(database, null, 2));
+
+      // Update metadata
+      const metadata: CacheMetadata = {
+        lastUpdate: new Date().toISOString(),
+        center: database.center,
+        radiusNM: database.radiusNM,
+        stationCount: database.stations.length,
+        noaaVersion: database.version
+      };
+      writeFileSync(this.metadataFile, JSON.stringify(metadata, null, 2));
+
+      this.app.debug(`Saved ${database.stations.length} stations to cache`);
+    } catch (error) {
+      this.app.error(`Failed to save harmonics cache: ${error}`);
+    }
+  }
+
+  /**
+   * Check if cache needs update
+   */
+  shouldUpdate(currentPosition: Position): { update: boolean; reason: string } {
+    const metadata = this.loadMetadata();
+
+    if (!metadata) {
+      return { update: true, reason: 'No cache exists' };
+    }
+
+    // Check if cache is too old
+    if (this.config.updateFrequency !== 'manual') {
+      const lastUpdate = new Date(metadata.lastUpdate);
+      const now = new Date();
+      const daysSinceUpdate = (now.getTime() - lastUpdate.getTime()) / (1000 * 60 * 60 * 24);
+
+      let maxDays = 365; // annual
+      if (this.config.updateFrequency === 'quarterly') maxDays = 90;
+      if (this.config.updateFrequency === 'semiannual') maxDays = 180;
+
+      if (daysSinceUpdate > maxDays) {
+        return { update: true, reason: `Cache expired (${Math.floor(daysSinceUpdate)} days old)` };
+      }
+    }
+
+    // Check if vessel moved too far from cache center
+    const distance = getDistance(
+      currentPosition,
+      metadata.center
+    ) / 1852; // Convert meters to nautical miles
+
+    if (distance > 300) {
+      return { update: true, reason: `Vessel moved ${distance.toFixed(0)}nm from cache center` };
+    }
+
+    // Check if we have enough nearby stations
+    const cache = this.loadCache();
+    if (cache) {
+      const nearbyStations = cache.stations.filter(station => {
+        const stationDistance = getDistance(
+          currentPosition,
+          { latitude: station.lat, longitude: station.lon }
+        ) / 1852;
+        return stationDistance <= this.config.autoDownloadRadius;
+      });
+
+      if (nearbyStations.length < this.config.minStations) {
+        return { update: true, reason: `Only ${nearbyStations.length} stations within ${this.config.autoDownloadRadius}nm (need ${this.config.minStations})` };
+      }
+    }
+
+    return { update: false, reason: 'Cache is current' };
+  }
+
+  /**
+   * Download harmonics data for a region
+   */
+  async downloadRegion(center: Position, radiusNM: number): Promise<HarmonicsDatabase | null> {
+    try {
+      this.app.setPluginStatus(`Downloading harmonics for ${radiusNM}nm radius...`);
+
+      // Fetch all stations
+      const allStations = await this.fetchAllStations();
+
+      // Filter by distance
+      const nearbyStations = allStations.filter((station: any) => {
+        const distance = getDistance(
+          center,
+          { latitude: parseFloat(station.lat), longitude: parseFloat(station.lng) }
+        ) / 1852;
+        return distance <= radiusNM;
+      });
+
+      this.app.debug(`Found ${nearbyStations.length} stations within ${radiusNM}nm`);
+
+      if (nearbyStations.length === 0) {
+        return null;
+      }
+
+      // Download harmonics and datums for each station
+      const stations: HarmonicStation[] = [];
+      for (let i = 0; i < nearbyStations.length; i++) {
+        const station = nearbyStations[i];
+
+        try {
+          const harmonicsData = await this.fetchStationHarmonics(station.id);
+          const datumOffset = await this.fetchStationDatum(station.id);
+          const converted = this.convertStation(station, harmonicsData, datumOffset);
+
+          if (converted) {
+            stations.push(converted);
+            this.app.debug(`Downloaded ${station.name} (${i + 1}/${nearbyStations.length})`);
+          }
+
+          // Rate limiting
+          await new Promise(resolve => setTimeout(resolve, 100));
+        } catch (error) {
+          this.app.error(`Failed to download ${station.name}: ${error}`);
+        }
+      }
+
+      // Create database
+      const database: HarmonicsDatabase = {
+        version: `noaa-${new Date().toISOString().split('T')[0]}`,
+        info: `NOAA CO-OPS harmonic constituents within ${radiusNM}nm of ${center.latitude}°, ${center.longitude}°. Auto-downloaded by SignalK Tides plugin.`,
+        source: 'NOAA Center for Operational Oceanographic Products and Services',
+        url: 'https://tidesandcurrents.noaa.gov/',
+        extracted: new Date().toISOString(),
+        center,
+        radiusNM,
+        stations: stations.sort((a, b) => b.lat - a.lat)
+      };
+
+      this.app.setPluginStatus(`Downloaded ${stations.length} stations`);
+      return database;
+
+    } catch (error) {
+      this.app.error(`Failed to download harmonics: ${error}`);
+      this.app.setPluginError(`Harmonics download failed: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Update cache if needed
+   */
+  async updateIfNeeded(currentPosition: Position): Promise<HarmonicsDatabase | null> {
+    const check = this.shouldUpdate(currentPosition);
+
+    if (!check.update) {
+      this.app.debug(`Harmonics cache up to date: ${check.reason}`);
+      return this.loadCache();
+    }
+
+    this.app.debug(`Updating harmonics cache: ${check.reason}`);
+
+    let radius = this.config.autoDownloadRadius;
+    let database: HarmonicsDatabase | null = null;
+
+    // Try expanding radius if we don't get enough stations
+    while (radius <= this.config.maxRadius) {
+      database = await this.downloadRegion(currentPosition, radius);
+
+      if (database && database.stations.length >= this.config.minStations) {
+        break;
+      }
+
+      if (this.config.expandRadiusIfNeeded && radius < this.config.maxRadius) {
+        this.app.debug(`Only found ${database?.stations.length || 0} stations, expanding radius to ${radius + 200}nm`);
+        radius += 200;
+      } else {
+        break;
+      }
+    }
+
+    if (database) {
+      this.saveCache(database);
+      return database;
+    }
+
+    // Return existing cache if download failed
+    return this.loadCache();
+  }
+
+  /**
+   * Helper methods for NOAA API
+   */
+  private async fetchAllStations(): Promise<any[]> {
+    const url = `${NOAA_BASE_URL}/stations.json?type=harcon`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    const data = await response.json() as { stations: any[] };
+    return data.stations;
+  }
+
+  private async fetchStationHarmonics(stationId: string): Promise<any> {
+    const url = `${NOAA_BASE_URL}/stations/${stationId}/harcon.json?units=metric`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    return await response.json();
+  }
+
+  private async fetchStationDatum(stationId: string): Promise<number> {
+    try {
+      const url = `${NOAA_BASE_URL}/stations/${stationId}/datums.json?units=metric`;
+      const response = await fetch(url);
+      if (!response.ok) return 0;
+
+      const data = await response.json() as { datums: any[] };
+      const datums = data.datums || [];
+      const msl = datums.find((d: any) => d.name === 'MSL');
+      const mllw = datums.find((d: any) => d.name === 'MLLW');
+
+      if (msl && mllw) {
+        return parseFloat(msl.value) - parseFloat(mllw.value);
+      }
+    } catch (error) {
+      this.app.debug(`Could not fetch datum for station ${stationId}`);
+    }
+    return 0;
+  }
+
+  private convertStation(stationData: any, harmonicsData: any, datumOffset: number): HarmonicStation | null {
+    const constituents: HarmonicConstituent[] = [];
+
+    for (const constituent of harmonicsData.HarmonicConstituents || []) {
+      if (PRIMARY_CONSTITUENTS.includes(constituent.name)) {
+        constituents.push({
+          name: constituent.name,
+          amplitude: parseFloat(constituent.amplitude),
+          phase: parseFloat(constituent.phase_GMT)
+        });
+      }
+    }
+
+    if (constituents.length < PRIMARY_CONSTITUENTS.length) {
+      return null;
+    }
+
+    constituents.sort((a, b) => a.name.localeCompare(b.name));
+
+    return {
+      id: stationData.id,
+      name: stationData.name,
+      lat: parseFloat(stationData.lat),
+      lon: parseFloat(stationData.lng),
+      timezone: stationData.timezone || 'UTC',
+      country: stationData.state || stationData.region || 'Unknown',
+      offset: datumOffset,
+      constituents
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,6 @@ export = function (app: SignalKApp): Plugin {
           description: "Display 'NOT FOR NAVIGATION' warning when using offline mode",
           default: true,
         },
-        // TODO: Add harmonics cache auto-download config (see .claude/future_harmonics_autodownload.md)
       }
     }),
     stop() {
@@ -217,7 +216,7 @@ export = function (app: SignalKApp): Plugin {
       }
 
       try {
-        const newForecast = await provider({ position: lastPosition });
+        let newForecast = await provider({ position: lastPosition });
 
         // Check if we should switch to this new station
         const threshold = (props.stationSwitchThreshold ?? 10) * 1000; // Convert km to meters
@@ -268,7 +267,7 @@ export = function (app: SignalKApp): Plugin {
             const offlineSource = sources.find(s => s.id === 'Offline');
             if (offlineSource) {
               const offlineProvider = await offlineSource.start(props);
-              const offlineForecast = await offlineProvider({ position: lastPosition });
+              let offlineForecast = await offlineProvider({ position: lastPosition });
 
               preferredStation = offlineForecast.station;
               lastForecast = offlineForecast;

--- a/src/sources/noaa.ts
+++ b/src/sources/noaa.ts
@@ -63,6 +63,11 @@ export default function (app: SignalKApp): TideSource {
               value: Number(v),
               time: new Date(`${t}Z`).toISOString(),
             })),
+            datum: {
+              source: 'MLLW',
+              // NOAA doesn't provide MSL offset in API, would need separate datum query
+              // For now, this will be estimated if user selects MSL
+            }
           };
         } catch (err: unknown) {
           const errorMessage = err instanceof Error ? err.message : String(err);

--- a/src/sources/noaa.ts
+++ b/src/sources/noaa.ts
@@ -64,9 +64,9 @@ export default function (app: SignalKApp): TideSource {
               time: new Date(`${t}Z`).toISOString(),
             })),
           };
-        } catch (err) {
-          app.setPluginError(`Failed to fetch NOAA tides: ${err}`);
-          // @ts-expect-error: app.error should accept more than just a string
+        } catch (err: unknown) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          app.setPluginError(`Failed to fetch NOAA tides: ${errorMessage}`);
           app.error(err);
           throw err;
         }

--- a/src/sources/offline.ts
+++ b/src/sources/offline.ts
@@ -1,0 +1,141 @@
+import TidePrediction from '@neaps/tide-predictor';
+import { getDistance } from 'geolib';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import type { SignalKApp, TideSource, TideForecastParams, TideForecastResult } from '../types.js';
+import harmonicsData from '../data/noaa-harmonics.json';
+
+interface HarmonicConstituent {
+  name: string;
+  amplitude: number;
+  phase: number;
+  [key: string]: number | string;
+}
+
+interface HarmonicStation {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  timezone: string;
+  country: string;
+  constituents: HarmonicConstituent[];
+}
+
+interface HarmonicsDatabase {
+  version: string;
+  info: string;
+  stations: HarmonicStation[];
+}
+
+/**
+ * Offline tide prediction using harmonic constituents
+ * Uses @neaps/tide-predictor with bundled harmonic database
+ */
+export default function (app: SignalKApp): TideSource {
+  return {
+    id: 'Offline',
+    title: 'Offline (Harmonic Prediction)',
+    properties: {},
+
+    start() {
+      app.debug("Offline harmonic tide prediction initialized");
+
+      // Try to load from cache first, fallback to bundled data
+      const cacheFile = join(app.getDataDirPath(), 'harmonics-cache', 'harmonics.json');
+      let database: HarmonicsDatabase;
+
+      if (existsSync(cacheFile)) {
+        try {
+          const data = readFileSync(cacheFile, 'utf-8');
+          database = JSON.parse(data) as HarmonicsDatabase;
+          app.debug(`Loaded ${database.stations.length} harmonic stations from cache (${database.version})`);
+        } catch (error) {
+          app.debug(`Failed to load cache, using bundled data: ${error}`);
+          database = harmonicsData as HarmonicsDatabase;
+          app.debug(`Loaded ${database.stations.length} harmonic stations from bundle (${database.version})`);
+        }
+      } else {
+        database = harmonicsData as HarmonicsDatabase;
+        app.debug(`Loaded ${database.stations.length} harmonic stations from bundle (${database.version})`);
+      }
+
+      return async (params: TideForecastParams): Promise<TideForecastResult> => {
+        const { position } = params;
+
+        // Find nearest station
+        const nearestStation = findNearestStation(position, database);
+        const distance = getDistance(
+          position,
+          { latitude: nearestStation.lat, longitude: nearestStation.lon }
+        );
+
+        app.debug(`Selected offline station: ${nearestStation.name} at ${(distance / 1000).toFixed(1)}km`);
+
+        // Generate predictions using @neaps/tide-predictor
+        // Start from 1 day ago to ensure we have historical data for interpolation
+        const now = new Date();
+        const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        const sevenDaysLater = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+        // Use offset if available (converts MLLW-relative predictions to MSL)
+        const offset = (nearestStation as any).offset || 0;
+
+        const prediction = TidePrediction(nearestStation.constituents, {
+          phaseKey: 'phase',
+          offset: offset  // Add datum offset from MLLW to MSL
+        });
+
+        const extremes = prediction.getExtremesPrediction({
+          start: oneDayAgo,
+          end: sevenDaysLater
+        });
+
+        // Convert to our TideForecastResult format
+        return {
+          station: {
+            name: `${nearestStation.name} (Offline)`,
+            position: {
+              latitude: nearestStation.lat,
+              longitude: nearestStation.lon
+            }
+          },
+          extremes: extremes.map((extreme: any) => ({
+            type: extreme.high ? 'High' : 'Low',
+            time: extreme.time.toISOString(),
+            value: extreme.level
+          }))
+        };
+      };
+    }
+  };
+}
+
+/**
+ * Find the nearest harmonic station to the given position
+ */
+function findNearestStation(
+  position: { latitude: number; longitude: number },
+  database: HarmonicsDatabase
+): HarmonicStation {
+  let nearest: HarmonicStation | null = null;
+  let minDistance = Infinity;
+
+  for (const station of database.stations) {
+    const distance = getDistance(
+      position,
+      { latitude: station.lat, longitude: station.lon }
+    );
+
+    if (distance < minDistance) {
+      minDistance = distance;
+      nearest = station;
+    }
+  }
+
+  if (!nearest) {
+    throw new Error('No harmonic stations available in database');
+  }
+
+  return nearest;
+}

--- a/src/sources/offline.ts
+++ b/src/sources/offline.ts
@@ -104,7 +104,11 @@ export default function (app: SignalKApp): TideSource {
             type: extreme.high ? 'High' : 'Low',
             time: extreme.time.toISOString(),
             value: extreme.level
-          }))
+          })),
+          datum: {
+            source: 'MSL',
+            mllwToMslOffset: offset
+          }
         };
       };
     }

--- a/src/sources/stormglass.ts
+++ b/src/sources/stormglass.ts
@@ -22,7 +22,7 @@ export default function (app: SignalKApp): TideSource {
         endPoint.search = new URLSearchParams({
           start: moment(date).format("YYYY-MM-DD"),
           end: moment(date).add(7, "days").format("YYYY-MM-DD"),
-          // datum: "CD",
+          datum: "MLLW",  // Request MLLW datum (StormGlass only supports MSL and MLLW)
           lat: position.latitude.toString(),
           lng: position.longitude.toString()
         }).toString();
@@ -37,6 +37,11 @@ export default function (app: SignalKApp): TideSource {
 
         const data = await res.json() as StormGlassApiResponse;
         app.debug(JSON.stringify(data, null, 2));
+
+        // Log StormGlass's datum offset for debugging data quality issues
+        if (data.meta.offset !== undefined) {
+          app.debug(`StormGlass offset: ${data.meta.offset}m (station: ${data.meta.station.source})`);
+        }
 
         return {
           station: {
@@ -53,6 +58,10 @@ export default function (app: SignalKApp): TideSource {
               time: new Date(time).toISOString(),
             };
           }),
+          datum: {
+            source: 'MLLW',  // StormGlass returns MLLW data when datum=MLLW is requested
+            // StormGlass doesn't provide MSL offset, will be estimated if needed
+          }
         };
       };
     }

--- a/src/sources/worldtides.ts
+++ b/src/sources/worldtides.ts
@@ -55,6 +55,10 @@ export default function (app: SignalKApp): TideSource {
               time: new Date(dt * 1000).toISOString(),
             };
           }),
+          datum: {
+            source: 'MLLW',  // WorldTides uses Chart Datum (CD) which is similar to MLLW
+            // WorldTides doesn't provide MSL offset, will be estimated if needed
+          }
         };
       };
 

--- a/src/sources/worldtides.ts
+++ b/src/sources/worldtides.ts
@@ -42,7 +42,7 @@ export default function (app: SignalKApp): TideSource {
 
         return {
           station: {
-            name: `${data.station} (${data.atlas})`,
+            name: data.station ? `${data.station} (${data.atlas})` : data.atlas,
             position: {
               latitude: data.responseLat,
               longitude: data.responseLon,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { Position, ServerAPI } from '@signalk/server-api';
 // TODO[TS]: remove these once @signalk/server-api has all the types needed.
+// @ts-expect-error - signalk-server internal types not properly exported
 import { WithConfig } from 'signalk-server/lib/app.js';
+// @ts-expect-error - signalk-server internal types not properly exported
 import { SignalKServer } from 'signalk-server/lib/types.js';
 
 // TODO[TS]: Fix this in the upstream types
@@ -46,4 +48,5 @@ export type Config = {
   period?: number;
   worldtidesApiKey?: string;
   stormglassApiKey?: string;
+  stationSwitchThreshold?: number;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,4 +49,8 @@ export type Config = {
   worldtidesApiKey?: string;
   stormglassApiKey?: string;
   stationSwitchThreshold?: number;
+  enableOfflineFallback?: boolean;
+  offlineMode?: 'auto' | 'always';
+  showOfflineWarning?: boolean;
+  // TODO: Add harmonics cache auto-download config types (see .claude/future_harmonics_autodownload.md)
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,10 @@ export interface TideForecastResult {
     };
   }
   extremes: TideExtreme[];
+  datum?: {
+    source: 'MSL' | 'MLLW';  // What datum the source data is in
+    mllwToMslOffset?: number;  // Offset in meters (MLLW + offset = MSL)
+  };
 }
 
 export type TideForecastFunction = (params: TideForecastParams) => OptionalPromise<TideForecastResult>;
@@ -52,5 +56,4 @@ export type Config = {
   enableOfflineFallback?: boolean;
   offlineMode?: 'auto' | 'always';
   showOfflineWarning?: boolean;
-  // TODO: Add harmonics cache auto-download config types (see .claude/future_harmonics_autodownload.md)
 };

--- a/src/types/neaps__tide-predictor.d.ts
+++ b/src/types/neaps__tide-predictor.d.ts
@@ -1,0 +1,47 @@
+declare module '@neaps/tide-predictor' {
+  interface TideConstituent {
+    name: string;
+    amplitude: number;
+    [phaseKey: string]: number | string;
+  }
+
+  interface TidePredictionOptions {
+    phaseKey?: string;
+    offset?: number;
+  }
+
+  interface TideExtreme {
+    time: Date;
+    level: number;
+    high: boolean;
+    low: boolean;
+    label: string;
+  }
+
+  interface ExtremesOptions {
+    start: Date;
+    end: Date;
+    timeFidelity?: number;
+    labels?: {
+      high?: string;
+      low?: string;
+    };
+  }
+
+  interface WaterLevelResult {
+    time: Date;
+    level: number;
+  }
+
+  interface TidePredictionInstance {
+    getExtremesPrediction(options: ExtremesOptions): TideExtreme[];
+    getWaterLevelAtTime(options: { time: Date }): WaterLevelResult;
+  }
+
+  function TidePrediction(
+    constituents: TideConstituent[],
+    options?: TidePredictionOptions
+  ): TidePredictionInstance;
+
+  export default TidePrediction;
+}

--- a/src/types/stormglass.d.ts
+++ b/src/types/stormglass.d.ts
@@ -12,9 +12,11 @@ export interface StormGlassExtreme {
 export interface StormGlassMeta {
   cost: number;
   dailyQuota: number;
+  datum?: string;
   end: string;
   lat: number;
   lng: number;
+  offset?: number;
   requestCount: number;
   start: string;
   station: StormGlassStation;

--- a/tools/extract-noaa-harmonics.mjs
+++ b/tools/extract-noaa-harmonics.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * Extract harmonic constituents from NOAA CO-OPS API
+ *
+ * This tool downloads harmonic constituent data for NOAA tide stations
+ * within a specified radius of a position and converts it to the format
+ * expected by the offline tide prediction source.
+ *
+ * Usage:
+ *   node extract-noaa-harmonics.mjs <latitude> <longitude> [radius_nm]
+ *
+ * Example:
+ *   node extract-noaa-harmonics.mjs -17.68 177.38 200
+ *
+ * NOAA API Documentation:
+ * - Station list: https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=harcon
+ * - Harmonics per station: https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/{id}/harcon.json
+ *
+ * Output format matches src/data/sample-harmonics.json schema
+ */
+
+import { writeFileSync } from 'fs';
+import { setTimeout } from 'timers/promises';
+
+const NOAA_BASE_URL = 'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi';
+const OUTPUT_FILE = './src/data/noaa-harmonics.json';
+const RATE_LIMIT_DELAY_MS = 100; // Delay between API requests to be respectful
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 2000;
+
+// We only need the primary 8 constituents that @neaps/tide-predictor uses
+// These are the most significant for tide prediction accuracy
+const PRIMARY_CONSTITUENTS = ['M2', 'S2', 'N2', 'K2', 'K1', 'O1', 'P1', 'Q1'];
+
+/**
+ * Calculate distance between two coordinates using Haversine formula
+ * @returns Distance in nautical miles
+ */
+function calculateDistance(lat1, lon1, lat2, lon2) {
+  const R = 3440.065; // Earth's radius in nautical miles
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+/**
+ * Fetch with retry logic
+ */
+async function fetchWithRetry(url, retries = MAX_RETRIES) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error(`Attempt ${attempt}/${retries} failed for ${url}: ${error.message}`);
+
+      if (attempt === retries) {
+        throw error;
+      }
+
+      await setTimeout(RETRY_DELAY_MS);
+    }
+  }
+}
+
+/**
+ * Fetch all NOAA stations with harmonic constituents
+ */
+async function fetchAllStations() {
+  console.log('Fetching station list from NOAA...');
+  const url = `${NOAA_BASE_URL}/stations.json?type=harcon`;
+  const data = await fetchWithRetry(url);
+
+  console.log(`Found ${data.count} stations with harmonic constituents`);
+  return data.stations;
+}
+
+/**
+ * Fetch harmonic constituents for a specific station
+ */
+async function fetchStationHarmonics(stationId) {
+  const url = `${NOAA_BASE_URL}/stations/${stationId}/harcon.json?units=metric`;
+  const data = await fetchWithRetry(url);
+  return data;
+}
+
+/**
+ * Fetch datum information for a specific station
+ * Returns the offset from MLLW to MSL in meters
+ */
+async function fetchStationDatum(stationId) {
+  try {
+    const url = `${NOAA_BASE_URL}/stations/${stationId}/datums.json?units=metric`;
+    const data = await fetchWithRetry(url);
+
+    // Find MLLW and MSL datums
+    const datums = data.datums || [];
+    const msl = datums.find(d => d.name === 'MSL');
+    const mllw = datums.find(d => d.name === 'MLLW');
+
+    if (msl && mllw) {
+      // Calculate offset: MSL - MLLW (both are absolute values relative to station datum)
+      const offset = parseFloat(msl.value) - parseFloat(mllw.value);
+      return offset;
+    }
+
+    return 0; // No datum offset available
+  } catch (error) {
+    console.warn(`  Could not fetch datum for station ${stationId}: ${error.message}`);
+    return 0;
+  }
+}
+
+/**
+ * Convert NOAA harmonic data to our format
+ */
+function convertStation(stationData, harmonicsData, datumOffset) {
+  const constituents = [];
+
+  // Extract only the primary constituents we need
+  for (const constituent of harmonicsData.HarmonicConstituents || []) {
+    if (PRIMARY_CONSTITUENTS.includes(constituent.name)) {
+      constituents.push({
+        name: constituent.name,
+        amplitude: parseFloat(constituent.amplitude),
+        phase: parseFloat(constituent.phase_GMT)
+      });
+    }
+  }
+
+  // Only include stations that have all 8 primary constituents
+  if (constituents.length < PRIMARY_CONSTITUENTS.length) {
+    return null;
+  }
+
+  // Sort constituents by name for consistency
+  constituents.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    id: stationData.id,
+    name: stationData.name,
+    lat: parseFloat(stationData.lat),
+    lon: parseFloat(stationData.lng),
+    timezone: stationData.timezone || 'UTC',
+    country: stationData.state || stationData.region || 'Unknown',
+    offset: datumOffset, // Offset from MLLW to MSL in meters
+    constituents
+  };
+}
+
+/**
+ * Main extraction process
+ */
+async function main() {
+  try {
+    // Parse command line arguments
+    const args = process.argv.slice(2);
+    if (args.length < 2) {
+      console.error('Usage: node extract-noaa-harmonics.mjs <latitude> <longitude> [radius_nm]');
+      console.error('Example: node extract-noaa-harmonics.mjs -17.68 177.38 200');
+      process.exit(1);
+    }
+
+    const centerLat = parseFloat(args[0]);
+    const centerLon = parseFloat(args[1]);
+    const radiusNM = args[2] ? parseFloat(args[2]) : 200;
+
+    if (isNaN(centerLat) || isNaN(centerLon) || isNaN(radiusNM)) {
+      console.error('Error: Invalid coordinates or radius');
+      process.exit(1);
+    }
+
+    console.log('Starting NOAA harmonic constituents extraction...');
+    console.log(`Center: ${centerLat}°, ${centerLon}°`);
+    console.log(`Radius: ${radiusNM} nautical miles\n`);
+
+    // Fetch all stations
+    const allStations = await fetchAllStations();
+
+    // Filter stations by distance
+    const nearbyStations = allStations.filter(station => {
+      const distance = calculateDistance(
+        centerLat,
+        centerLon,
+        parseFloat(station.lat),
+        parseFloat(station.lng)
+      );
+      return distance <= radiusNM;
+    });
+
+    console.log(`Found ${nearbyStations.length} stations within ${radiusNM}nm`);
+    console.log(`Processing stations...\n`);
+
+    const extractedStations = [];
+    let successCount = 0;
+    let failCount = 0;
+    let skippedCount = 0;
+
+    // Process each station
+    for (let i = 0; i < nearbyStations.length; i++) {
+      const station = nearbyStations[i];
+      const progress = `[${i + 1}/${nearbyStations.length}]`;
+      const distance = calculateDistance(
+        centerLat,
+        centerLon,
+        parseFloat(station.lat),
+        parseFloat(station.lng)
+      ).toFixed(1);
+
+      try {
+        console.log(`${progress} Fetching ${station.name} (${distance}nm)...`);
+
+        // Rate limiting
+        if (i > 0) {
+          await setTimeout(RATE_LIMIT_DELAY_MS);
+        }
+
+        const harmonicsData = await fetchStationHarmonics(station.id);
+        const datumOffset = await fetchStationDatum(station.id);
+
+        if (datumOffset > 0) {
+          console.log(`  Datum offset (MLLW to MSL): ${datumOffset.toFixed(3)}m`);
+        }
+
+        const converted = convertStation(station, harmonicsData, datumOffset);
+
+        if (converted) {
+          extractedStations.push(converted);
+          successCount++;
+        } else {
+          console.log(`  ⚠️  Skipped - missing primary constituents`);
+          skippedCount++;
+        }
+
+      } catch (error) {
+        console.error(`  ❌ Failed: ${error.message}`);
+        failCount++;
+      }
+    }
+
+    // Sort stations by latitude (north to south) for easier browsing
+    extractedStations.sort((a, b) => b.lat - a.lat);
+
+    // Create output database
+    const database = {
+      version: `noaa-${new Date().toISOString().split('T')[0]}`,
+      info: `NOAA CO-OPS harmonic constituents within ${radiusNM}nm of ${centerLat}°, ${centerLon}°. Contains ${extractedStations.length} stations with 8 primary tidal constituents (M2, S2, N2, K2, K1, O1, P1, Q1) for offline tide prediction.`,
+      source: 'NOAA Center for Operational Oceanographic Products and Services',
+      url: 'https://tidesandcurrents.noaa.gov/',
+      extracted: new Date().toISOString(),
+      center: { latitude: centerLat, longitude: centerLon },
+      radiusNM: radiusNM,
+      stations: extractedStations
+    };
+
+    // Write to file
+    console.log(`\nWriting ${extractedStations.length} stations to ${OUTPUT_FILE}...`);
+    writeFileSync(OUTPUT_FILE, JSON.stringify(database, null, 2));
+
+    // Calculate file size
+    const stats = await import('fs').then(fs => fs.statSync(OUTPUT_FILE));
+    const sizeKB = (stats.size / 1024).toFixed(2);
+
+    console.log('\n✅ Extraction complete!');
+    console.log(`\nStatistics:`);
+    console.log(`  Success: ${successCount}`);
+    console.log(`  Skipped: ${skippedCount} (incomplete constituent data)`);
+    console.log(`  Failed:  ${failCount}`);
+    console.log(`  Nearby:  ${nearbyStations.length}`);
+    console.log(`  Total:   ${allStations.length}`);
+    console.log(`\nOutput:`);
+    console.log(`  File:    ${OUTPUT_FILE}`);
+    console.log(`  Size:    ${sizeKB} KB`);
+    console.log(`  Stations: ${extractedStations.length}`);
+
+  } catch (error) {
+    console.error('\n❌ Fatal error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,6 +6,7 @@
     "lib": ["ES2023"],
     "module": "Node16",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
 
     /* Bundler mode */
     "moduleResolution": "node16",


### PR DESCRIPTION
Initially I just wanted to fix issue 31 as it was very annoying on my dashboard. Than I got capped by Stomglass.io and added a offline mode. Than I figured out that compared to the internet models stormglass was way off and my offline model even better. I know it is a big one, hope you like the work I did for the project. All the best from Fiji!

### Added

#### Offline Harmonic Prediction
- **Full offline mode** using NOAA harmonic constituents for accurate tide predictions without internet
- **Automatic harmonics cache** downloads stations within 500nm radius on startup and quarterly
- **Smart radius expansion** up to 1000nm if fewer than 2 stations found
- **Bundled harmonics data** for Fiji region (customizable with extraction tool)
- **Automatic fallback** to offline mode when online providers fail
- **MSL to MLLW datum conversion** using official NOAA datum offsets

#### Tidal Datum Support
- **Standardized on MLLW/CD datum** across all sources for marine navigation
- All tide heights now positive values (suitable for chart datum navigation)
- Automatic datum conversion where needed:
  - **NOAA**: Native MLLW datum (US standard)
  - **WorldTides**: Chart Datum (CD), equivalent to LAT
  - **StormGlass**: Requests MLLW datum from API
  - **Offline**: MSL with automatic MLLW conversion using NOAA datum offsets

#### Station Management
- **Smart station selection** prevents frequent switching between nearby tide stations
- **Configurable distance threshold** (default: 10km) for station switching
- **Position caching** maintains predictions when navigation.position temporarily unavailable

### Changed

- **Simplified configuration** - removed datum selection option (all sources now provide MLLW/CD)
- **Enhanced StormGlass integration** - requests MLLW datum, logs offset for debugging
- **Improved WorldTides** - handles missing station names gracefully

### Fixed

- **StormGlass datum parameter** - properly requests MLLW datum from API
- **WorldTides station names** - handles undefined station field (shows atlas name instead)
- **TypeScript errors** - fixed type definitions for StormGlass metadata (datum, offset fields)

### Documentation

- Added comprehensive datum explanation for all sources
- Added data quality warning for StormGlass UHSLC stations in Pacific
- Documented offline mode features and harmonics cache behavior
- Added recommendations for international waters (WorldTides or Offline)

### Technical Improvements

- Created `datum.ts` module for datum conversion utilities
- Created `harmonics-cache.ts` for automatic NOAA harmonics downloads
- Enhanced type safety with proper datum metadata in forecast results
- Removed unnecessary datum conversion code (all sources now MLLW/CD)