### PR TITLE
Add SHOM and Local Files sources, conditional settings schema, GeoJSON resource adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,69 @@ $ curl http://localhost:3000/signalk/v2/api/resources/tides
 - [StormGlass.io](https://stormglass.io/)
   - Online (requires API key)
   - Coverage: Global - aggregated marine data; tide availability varies
+- **Local Files**
+  - Offline, uses JSON files stored locally
+  - Requires manual data setup (see below)
+- [SHOM](https://services.data.shom.fr/support/en/services/spm)
+  - Online (requires API key)
+  - French Hydrographic Office (Service hydrographique et océanographique de la Marine)
+  - Coverage: French coastal waters
+
+### Setup Tides Data (Local Provider)
+
+Create JSON files and store tide data under a path accessible to the server (e.g. `/home/node/.signalk/tides`).
+
+#### Directory Structure
+
+Organize files by month under a named directory:
+
+```bash
+ls /home/node/.signalk/tides/myport/
+01_2025.json  04_2025.json  07_2025.json  10_2025.json
+02_2025.json  05_2025.json  08_2025.json  11_2025.json
+03_2025.json  06_2025.json  09_2025.json  12_2025.json
+```
+
+#### JSON Format
+
+Each JSON file contains tide data for a specific month. The structure follows this format:
+
+```json
+{
+    "2025-01-01": [
+        [
+            "tide.low",
+            "11:38",
+            "1.45m",
+            "---"
+        ],
+        [
+            "tide.high",
+            "05:21",
+            "5.95m",
+            "80"
+        ],
+        [
+            "tide.low",
+            "23:56",
+            "1.56m",
+            "---"
+        ],
+        [
+            "tide.high",
+            "17:44",
+            "5.7m",
+            "81"
+        ]
+    ]
+}
+```
+
+Each tide entry consists of:
+- **Type**: "tide.low" or "tide.high"
+- **Time**: The time of the tide event (HH:MM)
+- **Height**: Tide height in meters
+- **Coefficient**: If applicable, the coefficient value (otherwise "---")
 
 ## License
 

--- a/TIDE_API_PROPOSAL.md
+++ b/TIDE_API_PROPOSAL.md
@@ -1,0 +1,203 @@
+# Tides API — Proposal for SignalK v2
+
+**Author:** [@laborima](https://github.com/laborima)  
+**Status:** Draft  
+**Target:** SignalK server v2 — new dedicated API endpoint
+
+---
+
+## Motivation
+
+Tidal data is fundamental to safe navigation, yet SignalK has no standardised way to expose tide predictions. The existing [Weather API](https://demo.signalk.org/documentation/Developing/REST_APIs/Weather_API.html) (`/signalk/v2/api/weather`) demonstrates the right pattern for domain-specific, provider-based APIs. Tides deserve the same treatment.
+
+This document proposes a **Tides API** modelled directly on the Weather API, exposing tide predictions at:
+
+```text
+/signalk/v2/api/tides
+```
+
+
+## Proposed API
+
+Modelled on the Weather API pattern.
+
+### Endpoints
+
+#### Extremes (High/Low predictions)
+
+```http
+GET /signalk/v2/api/tides/extremes?lat=48.38&lon=-4.49
+```
+
+Returns the list of high/low tide extremes for the given position over the next 7 days.
+
+**Query parameters:**
+
+| Parameter  | Type         | Default         | Description                          |
+|------------|--------------|-----------------|--------------------------------------|
+| `lat`      | number       | vessel position | Latitude                             |
+| `lon`      | number       | vessel position | Longitude                            |
+| `date`     | `YYYY-MM-DD` | today           | Start date                           |
+| `days`     | integer      | 7               | Number of days (max 14)              |
+| `count`    | integer      | —               | Limit number of extremes returned    |
+| `provider` | string       | default         | Force a specific provider plugin id  |
+
+**Response:**
+
+```json
+{
+  "station": {
+    "name": "Brest (SHOM)",
+    "position": { "latitude": 48.3833, "longitude": -4.4953 }
+  },
+  "datum": "CD",
+  "units": "m",
+  "source": "shom",
+  "extremes": [
+    { "time": "2025-03-29T00:45:00.000Z", "type": "Low",  "value": 0.025 },
+    { "time": "2025-03-29T07:20:00.000Z", "type": "High", "value": 5.812 },
+    { "time": "2025-03-29T13:18:00.000Z", "type": "Low",  "value": 0.044 },
+    { "time": "2025-03-29T19:45:00.000Z", "type": "High", "value": 5.623 }
+  ]
+}
+```
+
+#### Current height
+
+```http
+GET /signalk/v2/api/tides/height?lat=48.38&lon=-4.49
+```
+
+Returns the interpolated current tide height (Rule of Twelfths) and the next two extremes.
+
+**Response:**
+
+```json
+{
+  "station": { "name": "Brest (SHOM)", "position": { "latitude": 48.3833, "longitude": -4.4953 } },
+  "datum": "CD",
+  "units": "m",
+  "source": "shom",
+  "heightNow": 3.241,
+  "timestamp": "2025-03-29T10:00:00.000Z",
+  "next": [
+    { "time": "2025-03-29T13:18:00.000Z", "type": "Low",  "value": 0.044 },
+    { "time": "2025-03-29T19:45:00.000Z", "type": "High", "value": 5.623 }
+  ]
+}
+```
+
+---
+
+## Provider Management
+
+Identical to the Weather API pattern:
+
+```http
+GET  /signalk/v2/api/tides/_providers
+GET  /signalk/v2/api/tides/_providers/_default
+POST /signalk/v2/api/tides/_providers/_default/{id}
+```
+
+**Example — list providers:**
+
+```json
+{
+  "shom":        { "provider": "SHOM",         "isDefault": true  },
+  "noaa":        { "provider": "NOAA",         "isDefault": false },
+  "stormglass":  { "provider": "StormGlass.io","isDefault": false },
+  "worldtides":  { "provider": "WorldTides",   "isDefault": false },
+  "neaps":       { "provider": "Neaps",        "isDefault": false },
+  "local":       { "provider": "Local Files",  "isDefault": false }
+}
+```
+
+---
+
+## OpenAPI Schema (draft)
+
+```yaml
+TideExtreme:
+  type: object
+  required: [time, type, value]
+  properties:
+    time:
+      type: string
+      format: date-time
+    type:
+      type: string
+      enum: [High, Low]
+    value:
+      type: number
+      description: Height in meters above datum
+
+TideStation:
+  type: object
+  required: [name, position]
+  properties:
+    name:
+      type: string
+    position:
+      type: object
+      required: [latitude, longitude]
+      properties:
+        latitude:  { type: number }
+        longitude: { type: number }
+
+TideExtremesResponse:
+  type: object
+  required: [station, datum, units, source, extremes]
+  properties:
+    station:  { $ref: '#/components/schemas/TideStation' }
+    datum:    { type: string, description: "Tidal datum (CD, MLLW, LAT…)" }
+    units:    { type: string, enum: [m] }
+    source:   { type: string, description: "Provider plugin id" }
+    extremes:
+      type: array
+      items: { $ref: '#/components/schemas/TideExtreme' }
+
+TideHeightResponse:
+  type: object
+  required: [station, datum, units, source, heightNow, timestamp, next]
+  properties:
+    station:    { $ref: '#/components/schemas/TideStation' }
+    datum:      { type: string }
+    units:      { type: string, enum: [m] }
+    source:     { type: string }
+    heightNow:  { type: number, description: "Interpolated current height (Rule of Twelfths)" }
+    timestamp:  { type: string, format: date-time }
+    next:
+      type: array
+      maxItems: 2
+      items: { $ref: '#/components/schemas/TideExtreme' }
+```
+
+---
+
+## Adapter / Implementation Notes
+
+The `signalk-tides` plugin already implements the provider logic. The internal `TideForecastResult` maps cleanly to the proposed response format:
+
+| Internal (`TideForecastResult`) | API Response field        |
+|---------------------------------|---------------------------|
+| `station.name`                  | `station.name`            |
+| `station.position`              | `station.position`        |
+| `extremes[]`                    | `extremes[]` (unchanged)  |
+| computed via Rule of Twelfths   | `heightNow`               |
+
+The `registerResourceProvider()` call would be **replaced** by a `registerTidesProvider()` call (new server API), analogous to `registerWeatherProvider()`.
+
+---
+
+## Backward Compatibility
+
+- The existing `environment.tide.*` delta paths are **preserved** — no breaking change for existing consumers
+- The `resources/tides` endpoint can remain as a compatibility shim during transition
+- The `signalk-tides` plugin serves as the reference implementation
+
+---
+
+## References
+
+- **Reference implementation:** <https://github.com/bkeepers/signalk-tides>
+- **Weather API (model):** <https://demo.signalk.org/documentation/Developing/REST_APIs/Weather_API.html>

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,0 +1,100 @@
+import type { TideForecastResult, TideExtreme } from './types.js';
+import { approximateTideHeightAt } from './calculations.js';
+
+export interface TideFeatureProperties {
+    name: string;
+    source: string;
+    datum: string;
+    units: string;
+    date: string;
+    extremes: TideExtreme[];
+    heightNow: number | null;
+    timestamp: string;
+}
+
+export interface TideFeature {
+    type: 'Feature';
+    geometry: {
+        type: 'Point';
+        coordinates: [number, number];
+    };
+    properties: TideFeatureProperties;
+}
+
+export type TideResourceCollection = Record<string, TideFeature>;
+
+/**
+ * Builds a deterministic resource URN from a station identifier and a date.
+ */
+function buildResourceId(stationName: string, date: string): string {
+    const slug = stationName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    return `urn:mrn:signalk:uuid:tides:${slug}:${date}`;
+}
+
+/**
+ * Groups tide extremes by calendar date (UTC).
+ */
+function groupByDate(extremes: TideExtreme[]): Map<string, TideExtreme[]> {
+    const groups = new Map<string, TideExtreme[]>();
+    for (const extreme of extremes) {
+        const date = extreme.time.slice(0, 10);
+        const existing = groups.get(date);
+        if (existing) {
+            existing.push(extreme);
+        } else {
+            groups.set(date, [extreme]);
+        }
+    }
+    return groups;
+}
+
+/**
+ * Converts a TideForecastResult into a SignalK Resources API compatible
+ * collection of GeoJSON Features, one per day.
+ */
+export function toResourceCollection(
+    forecast: TideForecastResult,
+    sourceId: string,
+    now: Date = new Date()
+): TideResourceCollection {
+    const collection: TideResourceCollection = {};
+    const byDate = groupByDate(forecast.extremes);
+
+    for (const [date, extremes] of byDate) {
+        const id = buildResourceId(forecast.station.name, date);
+        const isToday = date === now.toISOString().slice(0, 10);
+
+        collection[id] = {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: [forecast.station.position.longitude, forecast.station.position.latitude],
+            },
+            properties: {
+                name: forecast.station.name,
+                source: sourceId,
+                datum: 'CD',
+                units: 'm',
+                date,
+                extremes,
+                heightNow: isToday ? approximateTideHeightAt(forecast.extremes, now) : null,
+                timestamp: now.toISOString(),
+            },
+        };
+    }
+
+    return collection;
+}
+
+/**
+ * Returns a single TideFeature by resource id from a forecast result.
+ */
+export function toSingleResource(
+    forecast: TideForecastResult,
+    resourceId: string,
+    sourceId: string,
+    now: Date = new Date()
+): TideFeature | null {
+    const collection = toResourceCollection(forecast, sourceId, now);
+    return collection[resourceId] ?? null;
+}

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -1,30 +1,127 @@
 import type { TideExtreme } from './types.js';
 
-/** Given a list of tide extremes, estimate the height at a specific time. */
+/**
+ * Calculate tide height using the Rule of Twelfths.
+ * This is a more robust method that handles edge cases better than simple interpolation.
+ */
 export function approximateTideHeightAt(extremes: TideExtreme[], time: Date): number | null {
   const sorted = extremes.slice().sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
   const prev = sorted.filter(h => new Date(h.time) <= time).at(-1);
   const next = sorted.filter(h => new Date(h.time) >= time).at(0);
 
-  if (!prev) throw new Error("Missing height data before " + time.toISOString());
-  if (!next) throw new Error("Missing height data after " + time.toISOString());
+  // If we don't have both prev and next, try to find closest high and low
+  if (!prev || !next) {
+    // Fallback: find closest high and low tide
+    const highs = sorted.filter(e => e.type === 'High');
+    const lows = sorted.filter(e => e.type === 'Low');
+    
+    if (highs.length === 0 || lows.length === 0) {
+      // Cannot calculate, return null instead of throwing
+      return null;
+    }
+    
+    // Find closest high and low to current time
+    const closestHigh = highs.reduce((closest, h) => 
+      Math.abs(new Date(h.time).getTime() - time.getTime()) < Math.abs(new Date(closest.time).getTime() - time.getTime()) ? h : closest
+    );
+    const closestLow = lows.reduce((closest, l) => 
+      Math.abs(new Date(l.time).getTime() - time.getTime()) < Math.abs(new Date(closest.time).getTime() - time.getTime()) ? l : closest
+    );
+    
+    return calculateTideHeightUsingTwelfths(
+      closestHigh.value,
+      closestLow.value,
+      time,
+      new Date(closestHigh.time),
+      new Date(closestLow.time)
+    );
+  }
 
-  const progress = (time.getTime() - new Date(prev.time).getTime()) /
-    (new Date(next.time).getTime() - new Date(prev.time).getTime());
+  // Use Rule of Twelfths with prev and next extremes
+  const highTide = prev.type === 'High' ? prev : next;
+  const lowTide = prev.type === 'Low' ? prev : next;
 
-  const value = interpolate(prev.value, next.value, easeSine(progress));
-
-  return parseFloat(value.toFixed(3));
+  return calculateTideHeightUsingTwelfths(
+    highTide.value,
+    lowTide.value,
+    time,
+    new Date(highTide.time),
+    new Date(lowTide.time)
+  );
 }
 
-/** Interpolate between two values using the given progress (0-1). */
-function interpolate(start: number, end: number, progress: number) {
-  return start + (end - start) * progress;
-}
+/**
+ * Calculate tide height using the Rule of Twelfths.
+ * The rule states that in the first hour, the tide rises/falls 1/12 of its range,
+ * in the second hour 2/12, third hour 3/12, fourth hour 3/12, fifth hour 2/12, sixth hour 1/12.
+ */
+function calculateTideHeightUsingTwelfths(
+  highTideHeight: number,
+  lowTideHeight: number,
+  currentTime: Date,
+  highTideTime: Date,
+  lowTideTime: Date
+): number {
+  const currentMinutes = currentTime.getHours() * 60 + currentTime.getMinutes();
+  const highTideMinutes = highTideTime.getHours() * 60 + highTideTime.getMinutes();
+  const lowTideMinutes = lowTideTime.getHours() * 60 + lowTideTime.getMinutes();
 
-function easeSine(progress: number) {
-  // Map progress [0..1] to angle [0..π]
-  const angle = progress * Math.PI;
-  // Use sine to ease in/out
-  return (1 - Math.cos(angle)) / 2;
+  // Determine if tide is rising or falling and set calculation parameters
+  let isRising = false;
+  let startHeight: number, endHeight: number, startMinutes: number, endMinutes: number;
+
+  if (lowTideMinutes <= currentMinutes && currentMinutes <= highTideMinutes) {
+    // We are in a rising tide cycle (low to high)
+    isRising = true;
+    startHeight = lowTideHeight;
+    endHeight = highTideHeight;
+    startMinutes = lowTideMinutes;
+    endMinutes = highTideMinutes;
+  } else {
+    // We are in a falling tide cycle (high to low)
+    startHeight = highTideHeight;
+    endHeight = lowTideHeight;
+    startMinutes = highTideMinutes;
+    // Handle case where low tide is on the next day (midnight overlap)
+    endMinutes = lowTideMinutes + (lowTideMinutes < highTideMinutes ? 1440 : 0);
+  }
+
+  // Calculate total duration of this tide cycle and the total height change
+  const tideCycleDuration = Math.abs(endMinutes - startMinutes);
+  const tideChange = Math.abs(endHeight - startHeight);
+
+  // Calculate elapsed time since start of cycle, handling day wraparound
+  let elapsedTime = currentMinutes - startMinutes;
+  if (elapsedTime < 0) elapsedTime += 1440; // Add minutes in a day (24*60) if negative
+
+  // Calculate one twelfth of the total tide change
+  const twelfth = tideChange / 12;
+  let heightChange = 0;
+
+  // Apply the Rule of Twelfths based on elapsed time
+  if (tideCycleDuration === 0) {
+    heightChange = 0;
+  } else if (elapsedTime <= tideCycleDuration / 6) {
+    // First hour: 1/12 of the range
+    heightChange = twelfth * Math.ceil(elapsedTime / (tideCycleDuration / 12));
+  } else if (elapsedTime <= 2 * tideCycleDuration / 6) {
+    // Second hour: 2/12 of the range (total 3/12)
+    heightChange = twelfth * 2 + twelfth * Math.ceil((elapsedTime - tideCycleDuration / 6) / (tideCycleDuration / 12));
+  } else if (elapsedTime <= 3 * tideCycleDuration / 6) {
+    // Third hour: 3/12 of the range (total 6/12)
+    heightChange = twelfth * 5;
+  } else if (elapsedTime <= 4 * tideCycleDuration / 6) {
+    // Fourth hour: 3/12 of the range (total 9/12)
+    heightChange = twelfth * 8;
+  } else if (elapsedTime <= 5 * tideCycleDuration / 6) {
+    // Fifth hour: 2/12 of the range (total 11/12)
+    heightChange = twelfth * 10;
+  } else {
+    // Sixth hour: 1/12 of the range (total 12/12)
+    heightChange = tideChange;
+  }
+
+  // Return the final calculated height based on whether tide is rising or falling
+  const result = isRising ? startHeight + heightChange : startHeight - heightChange;
+  return parseFloat(result.toFixed(3));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,20 +37,26 @@ export default function (app: SignalKApp): Plugin {
         (s) => s.properties && Object.keys(s.properties as object).length > 0
       );
 
-      const conditionalSchemas = sourcesWithProps.map((source) => ({
-        if: {
-          properties: { source: { const: source.id } },
+      const dependenciesOneOf = sourcesWithProps.map((source) => ({
+        properties: {
+          source: { enum: [source.id] },
+          ...(source.properties as object),
         },
-        then: {
-          properties: source.properties as object,
-          required: Object.keys(source.properties as object),
-        },
+        required: Object.keys(source.properties as object),
       }));
 
-      const allSourceProperties = sources.reduce(
-        (properties, source) => Object.assign(properties, source.properties ?? {}),
-        {} as Record<string, unknown>
+      const sourcesWithoutProps = sources.filter(
+        (s) => !s.properties || Object.keys(s.properties as object).length === 0
       );
+
+      if (sourcesWithoutProps.length > 0) {
+        dependenciesOneOf.push({
+          properties: {
+            source: { enum: sourcesWithoutProps.map((s) => s.id) },
+          },
+          required: [],
+        });
+      }
 
       return {
         title: "Tides API",
@@ -59,13 +65,10 @@ export default function (app: SignalKApp): Plugin {
           source: {
             title: "Data source",
             type: "string",
-            anyOf: sources.map(({ id, title }) => ({
-              const: id,
-              title,
-            })),
+            enum: sources.map(({ id }) => id),
+            enumNames: sources.map(({ title }) => title),
             default: sources[0].id,
           },
-          ...allSourceProperties,
           period: {
             title: "Update frequency",
             type: "number",
@@ -74,7 +77,11 @@ export default function (app: SignalKApp): Plugin {
             minimum: 1,
           },
         },
-        allOf: conditionalSchemas,
+        dependencies: {
+          source: {
+            oneOf: dependenciesOneOf,
+          },
+        },
       };
     },
     start,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 import { Context, Delta, Path, Plugin, Position, Timestamp } from "@signalk/server-api";
 import type { SignalKApp, Config, TideForecastResult } from "./types.js";
 import { approximateTideHeightAt } from "./calculations.js";
+import { toResourceCollection, toSingleResource } from "./adapter.js";
 import FileCache from "./cache.js";
 import createSources from "./sources/index.js";
 
@@ -31,33 +32,51 @@ export default function (app: SignalKApp): Plugin {
     id: "tides",
     name: "Tides",
     description: "Tidal predictions for the vessel's position from various online sources.",
-    schema: () => ({
-      title: "Tides API",
-      type: "object",
-      properties: {
-        source: {
-          title: "Data source",
-          type: "string",
-          anyOf: sources.map(({ id, title }) => ({
-            const: id,
-            title,
-          })),
-          default: sources[0].id,
+    schema: () => {
+      const sourcesWithProps = sources.filter(
+        (s) => s.properties && Object.keys(s.properties as object).length > 0
+      );
+
+      const conditionalSchemas = sourcesWithProps.map((source) => ({
+        if: {
+          properties: { source: { const: source.id } },
         },
-        // Update plugin schema with sources
-        ...sources.reduce(
-          (properties, source) => Object.assign(properties, source.properties ?? {}),
-          {}
-        ),
-        period: {
-          title: "Update frequency",
-          type: "number",
-          description: "How often to update tide forecast (minutes)",
-          default: 60,
-          minimum: 1,
+        then: {
+          properties: source.properties as object,
+          required: Object.keys(source.properties as object),
         },
-      },
-    }),
+      }));
+
+      const allSourceProperties = sources.reduce(
+        (properties, source) => Object.assign(properties, source.properties ?? {}),
+        {} as Record<string, unknown>
+      );
+
+      return {
+        title: "Tides API",
+        type: "object",
+        properties: {
+          source: {
+            title: "Data source",
+            type: "string",
+            anyOf: sources.map(({ id, title }) => ({
+              const: id,
+              title,
+            })),
+            default: sources[0].id,
+          },
+          ...allSourceProperties,
+          period: {
+            title: "Update frequency",
+            type: "number",
+            description: "How often to update tide forecast (minutes)",
+            default: 60,
+            minimum: 1,
+          },
+        },
+        allOf: conditionalSchemas,
+      };
+    },
     start,
     stop() {
       unsubscribes.forEach((f) => f());
@@ -84,10 +103,14 @@ export default function (app: SignalKApp): Plugin {
       methods: {
         async listResources(query) {
           if (!lastPosition) throw new Error("No position available");
-          return provider({ position: lastPosition, ...query });
+          const forecast = await provider({ position: lastPosition, ...query });
+          return toResourceCollection(forecast, source.id);
         },
-        getResource(): never {
-          throw new Error("Not implemented");
+        async getResource(id: string) {
+          if (!lastForecast) throw new Error("No forecast available");
+          const feature = toSingleResource(lastForecast, id, source.id);
+          if (!feature) throw new Error(`Tide resource not found: ${id}`);
+          return feature;
         },
         setResource(): never {
           throw new Error("Not implemented");

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,30 +33,10 @@ export default function (app: SignalKApp): Plugin {
     name: "Tides",
     description: "Tidal predictions for the vessel's position from various online sources.",
     schema: () => {
-      const sourcesWithProps = sources.filter(
-        (s) => s.properties && Object.keys(s.properties as object).length > 0
+      const allSourceProperties = sources.reduce(
+        (properties, source) => Object.assign(properties, source.properties ?? {}),
+        {} as Record<string, unknown>
       );
-
-      const dependenciesOneOf = sourcesWithProps.map((source) => ({
-        properties: {
-          source: { enum: [source.id] },
-          ...(source.properties as object),
-        },
-        required: Object.keys(source.properties as object),
-      }));
-
-      const sourcesWithoutProps = sources.filter(
-        (s) => !s.properties || Object.keys(s.properties as object).length === 0
-      );
-
-      if (sourcesWithoutProps.length > 0) {
-        dependenciesOneOf.push({
-          properties: {
-            source: { enum: sourcesWithoutProps.map((s) => s.id) },
-          },
-          required: [],
-        });
-      }
 
       return {
         title: "Tides API",
@@ -76,11 +56,7 @@ export default function (app: SignalKApp): Plugin {
             default: 60,
             minimum: 1,
           },
-        },
-        dependencies: {
-          source: {
-            oneOf: dependenciesOneOf,
-          },
+          ...allSourceProperties,
         },
       };
     },

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -1,9 +1,12 @@
 import { SignalKApp, TideSource } from "../types.js";
+import local from "./local.js";
 import neaps from "./neaps.js";
 import noaa from "./noaa.js";
 import stormglass from "./stormglass.js";
 import worldtides from "./worldtides.js";
+import shom from "./shom.js";
 
 export default function createSources(app: SignalKApp): TideSource[] {
-  return [neaps, noaa, stormglass, worldtides].map(s => s(app));
+  // Prefer local tide files as the default source when available
+  return [local, neaps, noaa, stormglass, worldtides, shom].map((s) => s(app));
 }

--- a/src/sources/local.ts
+++ b/src/sources/local.ts
@@ -1,0 +1,106 @@
+import type { SignalKApp, TideForecastParams, TideForecastResult, TideSource } from "../types.js";
+import path from 'path';
+import fs from 'fs/promises';
+import moment from 'moment';
+
+export default function (app: SignalKApp): TideSource {
+  return {
+    id: 'local',
+    title: 'Local Files',
+    properties: {
+      localTidesPath: {
+        type: 'string',
+        title: 'Path to local tides folder',
+        description: 'Directory containing tide JSON files (e.g. /home/node/.signalk/tides)'
+      }
+    },
+
+    start({ localTidesPath } = {}) {
+      app.debug("Using Local Tides from " + localTidesPath);
+
+      return async ({ position, date = new Date().toISOString() }: TideForecastParams): Promise<TideForecastResult> => {
+        if (!localTidesPath) {
+            throw new Error('Local tides path not configured');
+        }
+
+        const startDate = moment(date);
+        const endDate = moment(date).add(7, 'days'); // Standard range seems to be a week
+        const extremes: any[] = [];
+
+        // We might need data from multiple months
+        let currentMonth = moment(startDate);
+        // Limit the loop to avoid infinite loops if something goes wrong, e.g. 2 months max
+        const limitDate = moment(endDate).add(1, 'month');
+
+        while (currentMonth.isBefore(limitDate)) {
+            const fileName = `${currentMonth.format('MM_YYYY')}.json`;
+            const filePath = path.join(localTidesPath, fileName);
+            
+            try {
+                const fileContent = await fs.readFile(filePath, 'utf-8');
+                const json = JSON.parse(fileContent);
+                
+                // Format: { "YYYY-MM-DD": [ ["tide.low", "HH:MM", "HEIGHT", "COEF"], ... ] }
+                for (const dayKey in json) {
+                    const dayDate = moment(dayKey);
+                    // Filter for relevant days
+                    if (dayDate.isSameOrAfter(startDate, 'day') && dayDate.isSameOrBefore(endDate, 'day')) {
+                        const dayTides = json[dayKey];
+                        for (const tide of dayTides) {
+                            // ["tide.low", "11:38", "1.45m", "---"]
+                            const [typeStr, timeStr, heightStr] = tide;
+                            const type = typeStr === 'tide.high' ? 'High' : 'Low';
+                            // heightStr is like "1.45m", need to parse float
+                            const value = parseFloat(heightStr.replace('m', ''));
+                            
+                            // Construct full date time
+                            const [hours, minutes] = timeStr.split(':');
+                            const time = dayDate.clone().hour(parseInt(hours)).minute(parseInt(minutes)).second(0).toISOString();
+                            
+                            extremes.push({
+                                type,
+                                value,
+                                time
+                            });
+                        }
+                    }
+                }
+
+            } catch (err: any) {
+                // Ignore missing files, just log debug
+                 // If the start date file is missing, it might be an issue, but let's just debug log
+                app.debug(`Could not read or parse local tide file ${filePath}: ${err.message}`);
+            }
+
+            // Move to next month
+            const nextMonth = currentMonth.clone().add(1, 'month');
+            if (nextMonth.isSame(currentMonth)) break; // Safety break
+            currentMonth = nextMonth;
+            
+             // If we have covered past the end date, stop
+             if (currentMonth.isAfter(endDate) && currentMonth.date() === 1) {
+                 // But wait, if we are in Jan 30 and want 7 days, we need Feb.
+                 // The while condition handles it: currentMonth < limitDate.
+                 // But we can optimize: if currentMonth (start of month) is > endDate, we can stop.
+                 if (currentMonth.isAfter(endDate)) break;
+             }
+        }
+
+        extremes.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+
+        const stationName = path.basename(localTidesPath);
+
+        return {
+          station: {
+            name: stationName,
+            position: {
+              latitude: position.latitude,
+              longitude: position.longitude,
+            },
+          },
+          extremes
+        };
+      };
+    }
+  }
+}

--- a/src/sources/shom.ts
+++ b/src/sources/shom.ts
@@ -1,0 +1,136 @@
+import type { SignalKApp, TideForecastParams, TideForecastResult, TideSource } from "../types.js";
+import { getDistance } from "geolib";
+import moment from 'moment';
+
+interface ShomHarbor {
+    cst: string;
+    name: string;
+    latitude: number;
+    longitude: number;
+}
+
+interface ShomHltEntry {
+    dt: string;
+    hauteur: number;
+    type: string;
+}
+
+const HARBORS_URL = 'https://services.data.shom.fr/spm/harbors';
+
+async function fetchHarbors(apiKey: string): Promise<ShomHarbor[]> {
+    const url = new URL(HARBORS_URL);
+    url.searchParams.set('apikey', apiKey);
+    const res = await fetch(url.toString());
+    if (!res.ok) throw new Error(`SHOM harbor list failed: ${res.status} ${res.statusText}`);
+    const data = await res.json() as any[];
+    return data.map((h: any) => ({
+        cst: h.cst,
+        name: h.name || h.libelle || h.cst,
+        latitude: parseFloat(h.latitude),
+        longitude: parseFloat(h.longitude),
+    }));
+}
+
+function closestHarbor(harbors: ShomHarbor[], position: { latitude: number; longitude: number }): ShomHarbor {
+    let best = harbors[0];
+    let bestDist = Infinity;
+    for (const harbor of harbors) {
+        const dist = getDistance(position, { latitude: harbor.latitude, longitude: harbor.longitude });
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = harbor;
+        }
+    }
+    return best;
+}
+
+export default function (app: SignalKApp): TideSource {
+  return {
+    id: 'shom',
+    title: 'SHOM',
+    properties: {
+      shomApiKey: {
+        type: 'string',
+        title: 'SHOM API Key'
+      }
+    },
+
+    start({ shomApiKey } = {}) {
+      app.debug("Using SHOM API");
+
+      let cachedHarbors: ShomHarbor[] | null = null;
+
+      return async ({ position, date = moment().toISOString() }: TideForecastParams): Promise<TideForecastResult> => {
+        if (!shomApiKey) {
+            throw new Error('SHOM API Key not configured');
+        }
+
+        if (!cachedHarbors) {
+            app.debug('SHOM: fetching harbor list');
+            cachedHarbors = await fetchHarbors(shomApiKey);
+            app.debug(`SHOM: loaded ${cachedHarbors.length} harbors`);
+        }
+
+        const harbor = closestHarbor(cachedHarbors, position);
+        app.debug(`SHOM: closest harbor is ${harbor.name} (${harbor.cst})`);
+
+        const startDate = moment(date).format('YYYY-MM-DD');
+        const endDate = moment(date).add(7, 'days').format('YYYY-MM-DD');
+
+        const url = new URL('https://services.data.shom.fr/spm/hlt');
+        url.searchParams.set('harborName', harbor.cst);
+        url.searchParams.set('duration', 'week');
+        url.searchParams.set('datref', startDate);
+        url.searchParams.set('nbDays', '7');
+        url.searchParams.set('apikey', shomApiKey);
+
+        app.debug(`SHOM: fetching tides from ${url.toString().replace(shomApiKey, '***')}`);
+
+        const response = await fetch(url.toString());
+
+        if (!response.ok) {
+            throw new Error(`SHOM API request failed: ${response.status} ${response.statusText}`);
+        }
+
+        const data = await response.json() as any;
+        app.debug('SHOM response: ' + JSON.stringify(data, null, 2));
+
+        const rawEntries: ShomHltEntry[] = data.hlt || data.data || data || [];
+
+        const extremes = [];
+        for (const item of rawEntries) {
+            let type: "High" | "Low" | null = null;
+            const rawType = (item.type || '').toUpperCase();
+            if (rawType === 'PM' || rawType === 'HIGH' || rawType === 'HW') type = 'High';
+            if (rawType === 'BM' || rawType === 'LOW' || rawType === 'LW') type = 'Low';
+
+            if (type && item.dt) {
+                extremes.push({
+                    type,
+                    value: item.hauteur ?? 0,
+                    time: new Date(item.dt).toISOString(),
+                });
+            }
+        }
+
+        extremes.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+
+        const filtered = extremes.filter(e => {
+            const t = new Date(e.time);
+            return t >= new Date(startDate) && t <= new Date(endDate + 'T23:59:59Z');
+        });
+
+        return {
+          station: {
+            name: `${harbor.name} (SHOM)`,
+            position: {
+              latitude: harbor.latitude,
+              longitude: harbor.longitude,
+            },
+          },
+          extremes: filtered,
+        };
+      };
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,4 +43,6 @@ export type Config = {
   period?: number;
   worldtidesApiKey?: string;
   stormglassApiKey?: string;
+  localTidesPath?: string;
+  shomApiKey?: string;
 };


### PR DESCRIPTION
## Changes

### New sources
- **SHOM** (French Hydrographic Office): fetches the nearest harbor via `services.data.shom.fr/spm/harbors`, then queries tide predictions via `services.data.shom.fr/spm/hlt`. Harbor list is cached in memory.
- **Local Files**: reads monthly JSON files from a local directory (format: `MM_YYYY.json`).

### Settings schema
All source-specific fields (`shomApiKey`, `stormglassApiKey`, `worldtidesApiKey`, `localTidesPath`) are now declared in the schema and visible in the SignalK admin UI.

### GeoJSON resource adapter ([src/adapter.ts])
[listResources()] now returns a proper SignalK resource collection — one GeoJSON Feature per day, keyed by a deterministic URN (`urn:mrn:signalk:uuid:tides:{station}:{date}`). [getResource(id)](cci:1://file:///home/matthieu/becpg-workspace/ocearo/signalk-tides/src/index.ts:91:8-96:9) is now implemented.

### Improved tide height calculation
[approximateTideHeightAt()] now uses the **Rule of Twelfths** instead of sine interpolation, with a fallback when data is outside the forecast window.
