### PR TITLE
Add Neaps API

### DIFF
--- a/app/components/TideChart.tsx
+++ b/app/components/TideChart.tsx
@@ -39,8 +39,8 @@ export function TideChart({
     setWidth(height / 4 * data.length)
   }, [height, data])
 
-  function displayDepth(value: number) {
-    return units === "m" ? `${value.toFixed(2)} m` : `${(value * 3.28084).toFixed(1)} ft`;
+  function displayDepth(level: number) {
+    return units === "m" ? `${level.toFixed(2)} m` : `${(level * 3.28084).toFixed(1)} ft`;
   }
 
   function displayTime(value: string) {
@@ -56,7 +56,7 @@ export function TideChart({
       .domain([min, max])
       .range([marginLeft, width - marginRight]);
 
-    const [yMin = 0, yMax = 0] = d3.extent(data, d => d.value)
+    const [yMin = 0, yMax = 0] = d3.extent(data, d => d.level)
     const yPad = (yMax - yMin) * .3;
 
     // Declare the y (vertical position) scale.
@@ -68,13 +68,13 @@ export function TideChart({
     area.current = d3.area<TideExtreme>()
       .curve(d3.curveMonotoneX)
       .x(d => x.current!(new Date(d.time)))
-      .y0(y.current!(d3.min(data, d => d.value - yPadding) ?? 0))
-      .y1(d => y.current!(d.value));
+      .y0(y.current!(d3.min(data, d => d.level - yPadding) ?? 0))
+      .y1(d => y.current!(d.level));
 
     line.current = d3.line<TideExtreme>()
       .curve(d3.curveMonotoneX)
       .x(d => x.current!(new Date(d.time)))
-      .y(d => y.current!(d.value))
+      .y(d => y.current!(d.level))
 
     if (gx.current) d3.select(gx.current).call(d3.axisBottom(x.current));
   }, [data, height, width, marginBottom, marginLeft, marginRight, marginTop])
@@ -121,19 +121,19 @@ export function TideChart({
                 <circle
                   className="TideChart__DataPoint"
                   cx={x.current?.(new Date(d.time))}
-                  cy={y.current?.(d.value)}
+                  cy={y.current?.(d.level)}
                   r={5}
                 />
                 {
                   (i !== 0 && i !== data.length - 1) &&
                   <text
-                    className={["TideChart__Text", `TideChart__Text--${d.type}`].join(" ")}
-                    y={d.type === "High" ? marginTop + textPadding : height - marginBottom - textPadding}
+                    className={["TideChart__Text", `TideChart__Text--${d.label}`].join(" ")}
+                    y={d.label === "High" ? marginTop + textPadding : height - marginBottom - textPadding}
                   >
-                    <tspan className="TideChart__Depth" x={x.current?.(new Date(d.time))} dy={d.type === "High" ? "1.5em" : "-1.5em"}>
-                      {displayDepth(d.value)}
+                    <tspan className="TideChart__Depth" x={x.current?.(new Date(d.time))} dy={d.label === "High" ? "1.5em" : "-1.5em"}>
+                      {displayDepth(d.level)}
                     </tspan>
-                    <tspan className="TideChart__Time" x={x.current?.(new Date(d.time))} dy={d.type === "High" ? "-1.5em" : "1.5em"}>
+                    <tspan className="TideChart__Time" x={x.current?.(new Date(d.time))} dy={d.label === "High" ? "-1.5em" : "1.5em"}>
                       {displayTime(d.time)}
                     </tspan>
                   </text>

--- a/app/components/TideChart.tsx
+++ b/app/components/TideChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as d3 from "d3";
 import { TideExtreme } from "../hooks/useTideData";
 import { useContainerDimensions } from "../hooks/useContainerDimensions";
@@ -23,14 +23,10 @@ export function TideChart({
   units = "m",
 }: TideChartProps) {
   const container = useRef<HTMLDivElement>(null);
-  const now = useRef<SVGLineElement>(null);
+  const nowLine = useRef<SVGLineElement>(null);
   const { height = 0 } = useContainerDimensions(container) || {};
   const [width, setWidth] = useState(0)
   const gx = useRef<SVGGElement>(null);
-  const x = useRef<d3.ScaleTime<number, number, never>>(null);
-  const y = useRef<d3.ScaleLinear<number, number, never>>(null);
-  const area = useRef<d3.Area<TideExtreme>>(null);
-  const line = useRef<d3.Line<TideExtreme>>(null);
   const textPadding = 25;
   const yPadding = 0.3; // meters
 
@@ -49,39 +45,46 @@ export function TideChart({
     }).format(new Date(value));
   }
 
-  useEffect(() => {
+  const scales = useMemo(() => {
+    if (!data.length || !width || !height) return null;
+
     const [min = 0, max = 0] = d3.extent(data, d => new Date(d.time));
 
-    x.current = d3.scaleTime()
+    const xScale = d3.scaleTime()
       .domain([min, max])
       .range([marginLeft, width - marginRight]);
 
     const [yMin = 0, yMax = 0] = d3.extent(data, d => d.level)
     const yPad = (yMax - yMin) * .3;
 
-    // Declare the y (vertical position) scale.
-    y.current = d3.scaleLinear()
+    const yScale = d3.scaleLinear()
       .domain([yMin - yPad, yMax + yPad])
       .range([height - marginBottom, marginTop]);
 
-    // Declare the area generator.
-    area.current = d3.area<TideExtreme>()
+    const areaGen = d3.area<TideExtreme>()
       .curve(d3.curveMonotoneX)
-      .x(d => x.current!(new Date(d.time)))
-      .y0(y.current!(d3.min(data, d => d.level - yPadding) ?? 0))
-      .y1(d => y.current!(d.level));
+      .x(d => xScale(new Date(d.time)))
+      .y0(yScale(d3.min(data, d => d.level - yPadding) ?? 0))
+      .y1(d => yScale(d.level));
 
-    line.current = d3.line<TideExtreme>()
+    const lineGen = d3.line<TideExtreme>()
       .curve(d3.curveMonotoneX)
-      .x(d => x.current!(new Date(d.time)))
-      .y(d => y.current!(d.level))
+      .x(d => xScale(new Date(d.time)))
+      .y(d => yScale(d.level))
 
-    if (gx.current) d3.select(gx.current).call(d3.axisBottom(x.current));
+    return { x: xScale, y: yScale, area: areaGen, line: lineGen };
   }, [data, height, width, marginBottom, marginLeft, marginRight, marginTop])
 
+  // Imperatively render the x-axis via d3
   useEffect(() => {
-    now.current?.scrollIntoView({ block: 'center', inline: 'center' })
-  }, [data, now, width])
+    if (scales && gx.current) {
+      d3.select(gx.current).call(d3.axisBottom(scales.x));
+    }
+  }, [scales])
+
+  useEffect(() => {
+    nowLine.current?.scrollIntoView({ block: 'center', inline: 'center' })
+  }, [data, width])
 
   return (
     <div className="TideChart" ref={container}>
@@ -98,18 +101,18 @@ export function TideChart({
           className="TideChart__LowWater"
           x1={marginLeft}
           x2={width - marginRight}
-          y1={y.current?.(0)}
-          y2={y.current?.(0)}
+          y1={scales?.y(0)}
+          y2={scales?.y(0)}
         />
 
-        <path fill="url(#gradient)" d={area.current?.(data) || ''} />
-        <path className="TideChart__Line" d={line.current?.(data) || ''} />
+        <path fill="url(#gradient)" d={scales?.area(data) || ''} />
+        <path className="TideChart__Line" d={scales?.line(data) || ''} />
 
         <line
-          ref={now}
+          ref={nowLine}
           className="TideChart__Now"
-          x1={x.current?.(new Date())}
-          x2={x.current?.(new Date())}
+          x1={scales?.x(new Date())}
+          x2={scales?.x(new Date())}
           y1={marginTop}
           y2={height - marginTop}
         />
@@ -120,8 +123,8 @@ export function TideChart({
               <g key={i}>
                 <circle
                   className="TideChart__DataPoint"
-                  cx={x.current?.(new Date(d.time))}
-                  cy={y.current?.(d.level)}
+                  cx={scales?.x(new Date(d.time))}
+                  cy={scales?.y(d.level)}
                   r={5}
                 />
                 {
@@ -130,10 +133,10 @@ export function TideChart({
                     className={["TideChart__Text", `TideChart__Text--${d.label}`].join(" ")}
                     y={d.label === "High" ? marginTop + textPadding : height - marginBottom - textPadding}
                   >
-                    <tspan className="TideChart__Depth" x={x.current?.(new Date(d.time))} dy={d.label === "High" ? "1.5em" : "-1.5em"}>
+                    <tspan className="TideChart__Depth" x={scales?.x(new Date(d.time))} dy={d.label === "High" ? "1.5em" : "-1.5em"}>
                       {displayDepth(d.level)}
                     </tspan>
-                    <tspan className="TideChart__Time" x={x.current?.(new Date(d.time))} dy={d.label === "High" ? "-1.5em" : "1.5em"}>
+                    <tspan className="TideChart__Time" x={scales?.x(new Date(d.time))} dy={d.label === "High" ? "-1.5em" : "1.5em"}>
                       {displayTime(d.time)}
                     </tspan>
                   </text>

--- a/app/hooks/useContainerDimensions.ts
+++ b/app/hooks/useContainerDimensions.ts
@@ -1,13 +1,10 @@
-import { RefObject, useLayoutEffect, useState } from "react";
-import useResizeObserver from '@react-hook/resize-observer'
+import { RefObject, useState } from "react";
+import useResizeObserver from "@react-hook/resize-observer";
 
-export function useContainerDimensions<T extends HTMLElement | null>(ref: RefObject<T>) {
-  const [size, setSize] = useState<DOMRect>()
-
-  useLayoutEffect(() => {
-    setSize(ref.current?.getBoundingClientRect())
-  }, [ref])
-
-  useResizeObserver(ref, (entry) => setSize(entry.contentRect))
-  return size
+export function useContainerDimensions<T extends HTMLElement | null>(
+  ref: RefObject<T>,
+) {
+  const [size, setSize] = useState<DOMRect>();
+  useResizeObserver(ref, (entry) => setSize(entry.contentRect));
+  return size;
 }

--- a/app/hooks/useTideData.ts
+++ b/app/hooks/useTideData.ts
@@ -1,19 +1,35 @@
 import { useEffect, useState } from "react";
-import { TideForecastResult, TideExtreme } from "../../src/types";
 
 const { VITE_SIGNALK_URL = window.location.toString() } = import.meta.env;
-export const API_URL = new URL("/signalk/v2/api/resources/tides", VITE_SIGNALK_URL).toString();
+export const API_URL = new URL("/signalk/v2/api/tides/extremes", VITE_SIGNALK_URL).toString();
 export const SETTINGS_URL = new URL("/#/serverConfiguration/plugins/tides", VITE_SIGNALK_URL).toString();
 
-export type { TideForecastResult, TideExtreme }
+export interface TideExtreme {
+  time: string;
+  level: number;
+  high: boolean;
+  low: boolean;
+  label: string;
+}
+
+export interface TideStation {
+  name: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface TideExtremesResult {
+  station: TideStation;
+  extremes: TideExtreme[];
+}
 
 export function useTideData() {
-  const [data, setData] = useState<TideForecastResult>()
+  const [data, setData] = useState<TideExtremesResult>()
 
   useEffect(() => {
     (async () => {
-      const res = await fetch(API_URL)
-      setData(await res.json())
+      const res = await fetch(API_URL);
+      setData(await res.json());
     })()
   }, []);
 

--- a/app/views/TidesView.tsx
+++ b/app/views/TidesView.tsx
@@ -11,7 +11,7 @@ export function TidesView() {
       <header className="p-6 mb-8 flex gap-8">
         <div className="flex-1">
           <h1 className="text-2xl font-semibold tracking-tight m-0 flex-1">{data?.station?.name}</h1>
-          {data?.station?.position && <Position {...data?.station?.position} />}
+          {data?.station && <Position latitude={data.station.latitude} longitude={data.station.longitude} />}
         </div>
         <div>
           <a href={SETTINGS_URL}>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@neaps/api": "^0.4.0",
     "@signalk/server-api": "^2.0",
+    "express": "^4.0",
     "geolib": "^3.3.4",
     "moment": "^2.30.1",
     "neaps": "^0.2.0"
@@ -41,6 +43,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@tailwindcss/vite": "^4.1.3",
     "@types/d3": "^7.4.3",
+    "@types/express": "^4.0",
     "@types/node": "^25.0.3",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export default function (app: SignalKApp): Plugin {
       methods: {
         async listResources(query) {
           if (!lastPosition) throw new Error("No position available");
-          return provider({ position: lastPosition, ...query });
+          return provider({ position: lastPosition, ...query }) as unknown as Record<string, unknown>;
         },
         getResource(): never {
           throw new Error("Not implemented");
@@ -153,8 +153,8 @@ export default function (app: SignalKApp): Plugin {
 
     async function updatePosition() {
       lastPosition =
-        app.getSelfPath("navigation.position.value") ||
-        (await cache.get("position")) ||
+        (app.getSelfPath("navigation.position.value") as Position | undefined) ||
+        ((await cache.get("position")) as Position | undefined) ||
         null;
 
       if (lastPosition) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,17 +15,33 @@
  */
 
 import { Context, Delta, Path, Plugin, Position, Timestamp } from "@signalk/server-api";
+import { RequestHandler } from "express";
+import { createRoutes } from "@neaps/api";
 import type { SignalKApp, Config, TideForecastResult } from "./types.js";
 import { approximateTideHeightAt } from "./calculations.js";
 import FileCache from "./cache.js";
 import createSources from "./sources/index.js";
+import { createAdapterRoutes } from "./routes.js";
 
 export default function (app: SignalKApp): Plugin {
   // Interval to update tide data
   const defaultPeriod = 60; // 1 hour
   let unsubscribes: (() => void)[] = [];
+  let activeRouter: RequestHandler | null = null;
 
   const sources = createSources(app);
+
+  const MOUNT_PATH = "/signalk/v2/api/tides";
+
+  // Mount forwarding middleware once (Express doesn't support unmounting)
+  // @ts-expect-error: app is an Express app at runtime
+  app.use(MOUNT_PATH, (req, res, next) => {
+    if (activeRouter) {
+      activeRouter(req, res, next);
+    } else {
+      next();
+    }
+  });
 
   const plugin: Plugin = {
     id: "tides",
@@ -62,6 +78,7 @@ export default function (app: SignalKApp): Plugin {
     stop() {
       unsubscribes.forEach((f) => f());
       unsubscribes = [];
+      activeRouter = null;
     },
   };
 
@@ -73,10 +90,28 @@ export default function (app: SignalKApp): Plugin {
     const cache = new FileCache(app.getDataDirPath());
 
     // Use the selected source, or the first one if not specified
-    const source = sources.find((source) => source.id === props.source) || sources[0];
+    const source =
+      sources.find((source) => source.id === props.source) || sources[0];
 
     // Load the selected source
     const provider = await source.start(props);
+
+    const getDefaultPosition = () => lastPosition;
+
+    // Set active router based on source
+    if (source.id === "neaps") {
+      const neapsRoutes = createRoutes({ prefix: MOUNT_PATH });
+      // Cast needed: @neaps/api bundles its own Express types that conflict with local ones
+      activeRouter = withDefaultPosition(
+        neapsRoutes as unknown as RequestHandler,
+        getDefaultPosition,
+      );
+    } else {
+      activeRouter = withDefaultPosition(
+        createAdapterRoutes(provider),
+        getDefaultPosition,
+      );
+    }
 
     // Register the source as a resource provider
     app.registerResourceProvider({
@@ -113,12 +148,14 @@ export default function (app: SignalKApp): Plugin {
       (subscriptionError) => {
         app.error("Error:" + subscriptionError);
       },
-      updatePosition
+      updatePosition,
     );
 
     async function updatePosition() {
       lastPosition =
-        app.getSelfPath("navigation.position.value") || (await cache.get("position")) || null;
+        app.getSelfPath("navigation.position.value") ||
+        (await cache.get("position")) ||
+        null;
 
       if (lastPosition) {
         await cache.set("position", lastPosition);
@@ -185,6 +222,24 @@ export default function (app: SignalKApp): Plugin {
     // Update every minute
     setInterval(updateTides, 60 * 1000);
   }
+
+  /** Middleware that injects default position into query when not provided */
+  function withDefaultPosition(
+    router: RequestHandler,
+    getPosition: () => Position | null,
+  ): RequestHandler {
+    return (req, res, next) => {
+      if (!req.query.latitude && !req.query.longitude) {
+        const pos = getPosition();
+        if (pos) {
+          req.query.latitude = String(pos.latitude);
+          req.query.longitude = String(pos.longitude);
+        }
+      }
+      router(req, res, next);
+    };
+  }
+
   function delay(time: number) {
     return new Promise((resolve) => setTimeout(resolve, time));
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,150 @@
+import { Router } from "express";
+import { openapi } from "@neaps/api";
+import { approximateTideHeightAt } from "./calculations.js";
+import type { TideExtreme, TideForecastFunction } from "./types.js";
+
+/**
+ * Create Express routes that implement a @neaps/api-compatible API
+ * backed by the given tide forecast provider.
+ */
+export function createAdapterRoutes(provider: TideForecastFunction) {
+  const router = Router();
+
+  router.get("/openapi.json", (_req, res) => {
+    res.json(openapi);
+  });
+
+  router.get("/extremes", async (req, res) => {
+    const { latitude, longitude, start, end } = req.query;
+
+    if (!latitude || !longitude) {
+      return res.status(400).json({ message: "latitude and longitude are required" });
+    }
+
+    try {
+      const result = await provider({
+        position: {
+          latitude: Number(latitude),
+          longitude: Number(longitude),
+        },
+        date: start ? String(start) : undefined,
+      });
+
+      const extremes = filterByTimeRange(result.extremes, start, end);
+
+      res.json({
+        station: result.station,
+        extremes: extremes.map(toNeapsExtreme),
+      });
+    } catch (error: unknown) {
+      res.status(500).json({ message: (error as Error).message });
+    }
+  });
+
+  router.get("/timeline", async (req, res) => {
+    const { latitude, longitude, start, end } = req.query;
+
+    if (!latitude || !longitude) {
+      return res.status(400).json({ message: "latitude and longitude are required" });
+    }
+
+    try {
+      const result = await provider({
+        position: {
+          latitude: Number(latitude),
+          longitude: Number(longitude),
+        },
+        date: start ? String(start) : undefined,
+      });
+
+      const startTime = start ? new Date(String(start)) : new Date();
+      const endTime = end
+        ? new Date(String(end))
+        : new Date(startTime.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+      const timeline = generateTimeline(result.extremes, startTime, endTime);
+
+      res.json({
+        station: result.station,
+        timeline,
+      });
+    } catch (error: unknown) {
+      res.status(500).json({ message: (error as Error).message });
+    }
+  });
+
+  // Station endpoints are not supported by non-neaps sources
+  router.get("/stations", (_req, res) => {
+    res.status(501).json({ message: "Station discovery is not supported by this data source" });
+  });
+
+  router.get("/stations/:source/:id", (_req, res) => {
+    res.status(501).json({ message: "Station lookup is not supported by this data source" });
+  });
+
+  router.get("/stations/:source/:id/extremes", (_req, res) => {
+    res.status(501).json({ message: "Station lookup is not supported by this data source" });
+  });
+
+  router.get("/stations/:source/:id/timeline", (_req, res) => {
+    res.status(501).json({ message: "Station lookup is not supported by this data source" });
+  });
+
+  return router;
+}
+
+/** Convert a TideExtreme to the @neaps/api extreme format */
+function toNeapsExtreme(e: TideExtreme) {
+  return {
+    time: e.time,
+    level: e.value,
+    high: e.type === "High",
+    low: e.type === "Low",
+    label: e.type,
+  };
+}
+
+function filterByTimeRange(
+  extremes: TideExtreme[],
+  start: unknown,
+  end: unknown
+) {
+  let filtered = extremes;
+  if (start) {
+    const startTime = new Date(String(start)).getTime();
+    filtered = filtered.filter((e) => new Date(e.time).getTime() >= startTime);
+  }
+  if (end) {
+    const endTime = new Date(String(end)).getTime();
+    filtered = filtered.filter((e) => new Date(e.time).getTime() <= endTime);
+  }
+  return filtered;
+}
+
+/**
+ * Generate a timeline of water levels at regular intervals by interpolating
+ * between known extremes using sine-eased approximation.
+ */
+function generateTimeline(
+  extremes: TideExtreme[],
+  start: Date,
+  end: Date,
+  intervalMinutes = 10
+) {
+  const timeline: { time: string; level: number }[] = [];
+  const intervalMs = intervalMinutes * 60 * 1000;
+
+  for (let t = start.getTime(); t <= end.getTime(); t += intervalMs) {
+    const time = new Date(t);
+    try {
+      const level = approximateTideHeightAt(extremes, time);
+      if (level !== null) {
+        timeline.push({ time: time.toISOString(), level });
+      }
+    } catch {
+      // Skip points outside the range of known extremes
+    }
+  }
+
+  return timeline;
+}


### PR DESCRIPTION
This plugin currently serves tide data through SignalK's Resource Provider API (`/signalk/v2/api/resources/tides`), returning only the current forecast for the vessel's position. The `@neaps/api` package provides a richer HTTP API with endpoints for extremes, timeline (water levels at intervals), and station search.

This is the second (cc #37) in a series of major improvements I'm planning to make to this plugin based on my work on the [Neaps](https://github.com/openwatersio/neaps) tide prediction engine.

When the "Neaps" source is selected, `@neaps/api` is used directly, which provides offline predictions for ~6k+ global tide stations.  When other sources are selected (NOAA, WorldTides, StormGlass), the plugin provides compatible (but limited) endpoints backed by those sources' data.

## @neaps/api Endpoints

The following endpoints are mounted under `/signalk/v2/api/tides/`:

| Endpoint | Description |
|----------|-------------|
| `GET /extremes?latitude=&longitude=&start=&end=&datum=&units=` | High/low tide predictions for coordinates |
| `GET /timeline?latitude=&longitude=&start=&end=&datum=&units=` | Water levels at regular intervals |
| `GET /stations?q=&latitude=&longitude=&limit=&radius=` | Station search by text or location |
| `GET /stations/:source/:id` | Individual station lookup |
| `GET /stations/:source/:id/extremes` | Station-specific extremes |
| `GET /stations/:source/:id/timeline` | Station-specific timeline |
| `GET /openapi.json` | OpenAPI 3.0 specification |

cc @laborima https://github.com/SignalK/signalk/discussions/213