### PR TITLE
Honour SignalK user-configured units for tide heights

### DIFF
--- a/app/components/TideChart.tsx
+++ b/app/components/TideChart.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import * as d3 from "d3";
 import { TideExtreme } from "../hooks/useTideData";
 import { useContainerDimensions } from "../hooks/useContainerDimensions";
+import type { DisplayUnit } from "../units";
 
 type TideChartProps = {
   width?: number;
@@ -10,7 +11,7 @@ type TideChartProps = {
   marginRight?: number;
   marginBottom?: number;
   marginLeft?: number;
-  units?: "m" | "ft";
+  heightUnit: DisplayUnit;
   data: TideExtreme[];
 };
 
@@ -20,7 +21,7 @@ export function TideChart({
   marginRight = 6,
   marginBottom = 30,
   marginLeft = 6,
-  units = "m",
+  heightUnit,
 }: TideChartProps) {
   const container = useRef<HTMLDivElement>(null);
   const nowLine = useRef<SVGLineElement>(null);
@@ -36,7 +37,7 @@ export function TideChart({
   }, [height, data])
 
   function displayDepth(level: number) {
-    return units === "m" ? `${level.toFixed(2)} m` : `${(level * 3.28084).toFixed(1)} ft`;
+    return `${heightUnit.toDisplay(level).toFixed(heightUnit.decimals)} ${heightUnit.symbol}`;
   }
 
   function displayTime(value: string) {

--- a/app/hooks/useUnitPreferences.ts
+++ b/app/hooks/useUnitPreferences.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+const { VITE_SIGNALK_URL = window.location.toString() } = import.meta.env;
+export const UNIT_PREFERENCES_URL = new URL(
+  "/signalk/v1/unitpreferences/active",
+  VITE_SIGNALK_URL,
+).toString();
+
+export interface CategoryPref {
+  baseUnit: string;
+  targetUnit: string;
+  symbol?: string;
+  formula?: string;
+  inverseFormula?: string;
+  displayFormat?: string;
+}
+
+export interface ActivePreset {
+  name?: string;
+  categories: Record<string, CategoryPref>;
+}
+
+export type UnitPreferencesStatus = "loading" | "ready" | "unsupported";
+
+export interface UnitPreferences {
+  depth: CategoryPref | null;
+  status: UnitPreferencesStatus;
+}
+
+// Reads the active SignalK unit-preferences preset so the webapp can honour
+// the units the user configured on the server (per-user when logged in,
+// server default otherwise). Falls back to `unsupported` on older servers
+// that don't expose /signalk/v1/unitpreferences/active.
+export function useUnitPreferences(): UnitPreferences {
+  const [prefs, setPrefs] = useState<UnitPreferences>({
+    depth: null,
+    status: "loading",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(UNIT_PREFERENCES_URL, { credentials: "include" });
+        if (!res.ok) {
+          if (!cancelled) setPrefs({ depth: null, status: "unsupported" });
+          return;
+        }
+        const body = (await res.json()) as ActivePreset;
+        if (cancelled) return;
+        setPrefs({
+          depth: body.categories?.depth ?? null,
+          status: "ready",
+        });
+      } catch {
+        if (!cancelled) setPrefs({ depth: null, status: "unsupported" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return prefs;
+}

--- a/app/units.ts
+++ b/app/units.ts
@@ -1,0 +1,82 @@
+import type { CategoryPref } from "./hooks/useUnitPreferences";
+
+export interface DisplayUnit {
+  toDisplay: (siMeters: number) => number;
+  symbol: string;
+  decimals: number;
+}
+
+const METERS_TO_FEET = 3.28084;
+
+const METERS: DisplayUnit = {
+  toDisplay: (m) => m,
+  symbol: "m",
+  decimals: 2,
+};
+
+const FEET: DisplayUnit = {
+  toDisplay: (m) => m * METERS_TO_FEET,
+  symbol: "ft",
+  decimals: 1,
+};
+
+let warnedUnsupported: string | null = null;
+
+// Derives a DisplayUnit for tide heights from the active preset's `depth`
+// category. When the server doesn't expose unit preferences (older server or
+// missing category), falls back to the locale-based guess that matches the
+// webapp's prior behaviour.
+export function heightUnitFromPreset(
+  depth: CategoryPref | null,
+  fallbackLocale: string,
+): DisplayUnit {
+  if (!depth) return localeFallback(fallbackLocale);
+
+  const { targetUnit, symbol, displayFormat } = depth;
+
+  if (targetUnit === "foot") {
+    return {
+      toDisplay: FEET.toDisplay,
+      // The server's standard definition returns symbol:"foot"; we prefer the
+      // conventional "ft" for marine UI.
+      symbol: FEET.symbol,
+      decimals: parseDisplayFormat(displayFormat, FEET.decimals),
+    };
+  }
+
+  if (targetUnit === "m") {
+    return {
+      toDisplay: METERS.toDisplay,
+      symbol: symbol ?? METERS.symbol,
+      decimals: parseDisplayFormat(displayFormat, METERS.decimals),
+    };
+  }
+
+  // Unknown / custom target unit: we can't evaluate arbitrary mathjs formulas
+  // without pulling in the full library, so display in SI meters. See the PR
+  // for a follow-up to generalise this.
+  if (warnedUnsupported !== targetUnit) {
+    warnedUnsupported = targetUnit;
+    console.warn(
+      `[signalk-tides] Unsupported depth targetUnit "${targetUnit}" in active unit preferences; displaying metres.`,
+    );
+  }
+  return {
+    toDisplay: METERS.toDisplay,
+    symbol: METERS.symbol,
+    decimals: parseDisplayFormat(displayFormat, METERS.decimals),
+  };
+}
+
+function localeFallback(locale: string): DisplayUnit {
+  return locale === "en-US" ? FEET : METERS;
+}
+
+// Parses the SignalK displayFormat pattern ("0.0", "0.00", ...) into a
+// digit count. Anything unrecognised falls back to the caller's default.
+export function parseDisplayFormat(fmt: string | undefined, fallback: number): number {
+  if (!fmt) return fallback;
+  const match = /^0+(?:\.(0+))?$/.exec(fmt);
+  if (!match) return fallback;
+  return match[1]?.length ?? 0;
+}

--- a/app/views/TidesView.tsx
+++ b/app/views/TidesView.tsx
@@ -1,10 +1,13 @@
 import { SETTINGS_URL, useTideData } from "../hooks/useTideData";
+import { useUnitPreferences } from "../hooks/useUnitPreferences";
+import { heightUnitFromPreset } from "../units";
 import { Position } from '../components/Position';
 import { TideChart } from '../components/TideChart'
 
 export function TidesView() {
   const data = useTideData();
-  const units = navigator.language === 'en-US' ? 'ft' : 'm';
+  const { depth, status: unitStatus } = useUnitPreferences();
+  const heightUnit = heightUnitFromPreset(depth, navigator.language);
 
   return (
     <>
@@ -23,8 +26,8 @@ export function TidesView() {
         </div>
       </header >
       {
-        data?.extremes ?
-          <TideChart data={data.extremes} units={units} /> :
+        data?.extremes && unitStatus !== "loading" ?
+          <TideChart data={data.extremes} heightUnit={heightUnit} /> :
           <LoadingTidesView />
       }
     </>


### PR DESCRIPTION
## Summary

Today the tides webapp picks the height unit with a browser-locale guess:

```ts
const units = navigator.language === 'en-US' ? 'ft' : 'm';
```

That ignores whatever the user actually set on their SignalK server. A US sailor running metric presets still sees feet; a European visitor to a US boat sees metres. Both are wrong.

Signal K Server 2.x exposes a first-class [Unit Preferences API](https://github.com/SignalK/signalk-server/blob/master/docs/guides/unitpreferences.md) with per-user, preset-based display units (`/signalk/v1/unitpreferences/active`). This PR wires the webapp to that API and uses the server's `depth` category (`targetUnit`, `symbol`, `displayFormat`) to format heights.

## Changes

- New `useUnitPreferences` hook fetching the active preset with `credentials: 'include'` (per-user when logged in, server default otherwise).
- New `units.ts` helper that maps the `depth` category to a small `DisplayUnit` (conversion + symbol + decimals). Handles `m` and `foot` explicitly (the only target units the six built-in presets use for depth) and warns once on unknown units.
- `TidesView` passes a `DisplayUnit` to `TideChart` instead of the `'m' | 'ft'` literal.
- `TideChart.displayDepth` applies the conversion/symbol/decimals directly.
- Loading indicator stays up until both tide data *and* unit preferences are resolved, so the chart doesn't flash with fallback units for one frame.

## Fallback

If the server returns 404 or any other error (older server without the unit-preferences API), the webapp keeps the previous `navigator.language === 'en-US' ? ft : m` behaviour, so nothing breaks for users on pre-2.x servers.

## Not in this PR

- **Server-side plugin code.** The plugin already emits SI metres, which is correct; no changes under `src/`.
- **Time formatting.** `TideChart` already uses `Intl.DateTimeFormat` with `timeStyle: 'short'`, which honours the OS/browser locale; unchanged.
- **Generalised formula evaluation.** The unit-preferences `displayUnits` includes a mathjs formula string. Pulling mathjs in for two linear conversions felt heavy, so this PR hardcodes `m` and `foot`. A follow-up could use `new Function` with a whitelist regex or a small mathjs subset to transparently support custom presets with `targetUnit: 'yard'`, `'cm'`, etc.
- **`default-categories.json` upstream.** `environment.tide.heightHigh/heightLow/heightNow` are not currently mapped to the `depth` category in signalk-server, which would be a nice consistency win for deltas/meta. That's an upstream PR against SignalK/signalk-server, not this repo.

## Test plan

- [x] `npm run build` succeeds (tsc + vite build clean).
- [x] `npm run lint` — no new errors introduced (the pre-existing `react-hooks/set-state-in-effect` warning in `TideChart.tsx:36` is on code this PR doesn't touch).
- [ ] Manual: switch the active preset in **Server Admin → Settings → Unit Preferences** between *Metric* and *Imperial (US)*, reload the webapp. Chart labels flip between `1.93 m` and `6.3 ft`.
- [ ] Manual: point the webapp at a server without the unit-preferences endpoint (or mock a 404). Labels fall back to the locale-based guess; console stays quiet.