### PR TITLE
perf: gate JSON.stringify behind debug.enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,9 @@ export default function (app: SignalKApp): Plugin {
   };
 
   async function start(props: Config) {
-    app.debug("Starting tides-api: " + JSON.stringify(props));
+    if (app.debug.enabled) {
+      app.debug("Starting tides-api: " + JSON.stringify(props));
+    }
 
     let lastForecast: TideForecastResult | null = null;
     let lastPosition: Position | null = null;
@@ -213,7 +215,9 @@ export default function (app: SignalKApp): Plugin {
         ],
       };
 
-      app.debug("Sending delta: " + JSON.stringify(delta));
+      if (app.debug.enabled) {
+        app.debug("Sending delta: " + JSON.stringify(delta));
+      }
       app.handleMessage(plugin.id, delta);
     }
 

--- a/src/sources/noaa.ts
+++ b/src/sources/noaa.ts
@@ -65,7 +65,9 @@ export default function (app: SignalKApp): TideSource {
           if (!res.ok)
             throw new Error("Failed to fetch NOAA tides: " + res.statusText);
           const body = (await res.json()) as NoaaPredictionApiResponse;
-          app.debug("NOAA response: \n" + JSON.stringify(body, null, 2));
+          if (app.debug.enabled) {
+            app.debug("NOAA response: \n" + JSON.stringify(body, null, 2));
+          }
 
           if (body.error) throw new Error(body.error.message);
 

--- a/src/sources/stormglass.ts
+++ b/src/sources/stormglass.ts
@@ -36,7 +36,9 @@ export default function (app: SignalKApp): TideSource {
         if (!res.ok) throw new Error('Failed to fetch StormGlass.io: ' + res.statusText);
 
         const data = await res.json() as StormGlassApiResponse;
-        app.debug(JSON.stringify(data, null, 2));
+        if (app.debug.enabled) {
+          app.debug(JSON.stringify(data, null, 2));
+        }
 
         return {
           station: {

--- a/src/sources/worldtides.ts
+++ b/src/sources/worldtides.ts
@@ -36,7 +36,9 @@ export default function (app: SignalKApp): TideSource {
         if (!res.ok) throw new Error('Failed to fetch worldtides: ' + res.statusText);
 
         const data = await res.json() as WorldTidesPredictionApiResponse;
-        app.debug(JSON.stringify(data, null, 2));
+        if (app.debug.enabled) {
+          app.debug(JSON.stringify(data, null, 2));
+        }
 
         if (data.status != 200) throw new Error("worldtides data: " + data.error ? data.error : "none");
 


### PR DESCRIPTION
Five call sites across `src/index.ts` and `src/sources/{noaa,stormglass,worldtides}.ts` run

```ts
app.debug("... " + JSON.stringify(...))
```

unconditionally. With debug logging off (the production default), `JSON.stringify` still runs eagerly, allocating short-lived strings that hammer the young-generation GC.

This is one of the bigger perf taxes a SignalK plugin pays: the serialize cost compounds with GC pressure on hot paths. The same class of fix on `course-provider-plugin`'s dispatcher cut latency by ~70 % and dropped ~700 b/op of allocations on a single hot call site.

Most of these sites are start- or fetch-driven (low frequency); the `Sending delta` one in `index.ts` fires per tide-delta emit.

## Change

- `src/index.ts` — wrap two call sites with `if (app.debug.enabled)`.
- `src/sources/noaa.ts`, `src/sources/stormglass.ts`, `src/sources/worldtides.ts` — same.

Tracking issue across the SignalK ecosystem: [SignalK/signalk-server#2582](https://github.com/SignalK/signalk-server/issues/2582).