### PR TITLE
Fix SignalKApp typing for app.debug.enabled

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
 import { Position, ServerAPI } from "@signalk/server-api";
 
-// TODO[TS]: Fix this in the upstream types
-export type SignalKApp = ServerAPI;
+// Workaround pending an upstream type fix in @signalk/server-api: at runtime
+// `app.debug` is a debug-module instance with an `.enabled` property, but
+// ServerAPI types it as a bare function. Omit the upstream `debug` member
+// before intersecting so the property doesn't collapse to `never`.
+export type SignalKApp = Omit<ServerAPI, "debug"> & {
+  debug: ServerAPI["debug"] & { enabled: boolean };
+};
 
 export type OptionalPromise<T> = T | Promise<T>;
 


### PR DESCRIPTION
Noticed CI on main has been red since #73 landed — `@signalk/server-api` types `app.debug` as a bare function, so the `debug.enabled` gates don't compile (no lockfile in the repo, so CI floats to 2.25.0 and hits it every run).

At runtime `app.debug` is a debug-module instance, which does have `.enabled`, so this just teaches `SignalKApp` about it in types.ts. The real fix is upstream — server-api typing `debug` as `import('debug').Debugger` — happy to send that PR to signalk-server too if you want.
