### PR TITLE
Add environment.tide.state and timeToNextExtreme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It publishes the following [tide data](https://signalk.org/specification/1.7.0/d
 * `environment.tide.timeLow`
 * `environment.tide.heightNow`
 * `environment.tide.stationName`
+* `environment.tide.state` — tide trend, `rising` or `falling`
+* `environment.tide.timeToNextExtreme` — seconds until the next high or low water
 
 ### Tides resource
 

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -9,8 +9,12 @@ export function approximateTideHeightAt(extremes: Extreme[], time: Date): number
   if (!prev) throw new Error("Missing height data before " + time.toISOString());
   if (!next) throw new Error("Missing height data after " + time.toISOString());
 
-  const progress = (time.getTime() - prev.time.getTime()) /
-    (next.time.getTime() - prev.time.getTime());
+  const prevTime = prev.time.getTime();
+  const nextTime = next.time.getTime();
+  // Exactly at an extreme prev === next; avoid 0/0 -> NaN
+  if (prevTime === nextTime) return parseFloat(prev.level.toFixed(3));
+
+  const progress = (time.getTime() - prevTime) / (nextTime - prevTime);
 
   const value = interpolate(prev.level, next.level, easeSine(progress));
 
@@ -27,4 +31,44 @@ function easeSine(progress: number) {
   const angle = progress * Math.PI;
   // Use sine to ease in/out
   return (1 - Math.cos(angle)) / 2;
+}
+
+export type TideState = "rising" | "falling";
+
+/**
+ * Trend of the tide at `time`: "rising" if the next extreme is a High,
+ * "falling" if it is a Low.
+ *
+ * Boundary: at the instant of an extreme the extreme itself satisfies
+ * `extreme.time >= time`, so it is still "next", and the state reads as that
+ * extreme's own type — e.g. "falling" with timeToNextExtreme 0 at the instant
+ * of low water — flipping on the following tick. Simplest consistent rule at
+ * one-minute resolution.
+ *
+ * Returns null when the forecast has no upcoming extreme (stale data).
+ */
+export function tideStateAt(extremes: Extreme[], time: Date): TideState | null {
+  const next = nextExtremeAt(extremes, time);
+  if (!next) return null;
+  return next.high ? "rising" : "falling";
+}
+
+/** First extreme at or after `time`, or undefined. Tolerates unsorted input. */
+function nextExtremeAt(extremes: Extreme[], time: Date): Extreme | undefined {
+  return extremes
+    .slice()
+    .sort((a, b) => a.time.getTime() - b.time.getTime())
+    .find((extreme) => extreme.time >= time);
+}
+
+/**
+ * Whole seconds (rounded up) until the next tide extreme (high or low water)
+ * at `time`, or null when the forecast has no upcoming extreme. Ceiling keeps
+ * the countdown > 0 until the extreme is actually reached; see tideStateAt
+ * for the exactly-at-extreme boundary behaviour (this returns 0 for that tick).
+ */
+export function timeToNextExtreme(extremes: Extreme[], time: Date): number | null {
+  const next = nextExtremeAt(extremes, time);
+  if (!next) return null;
+  return Math.ceil((next.time.getTime() - time.getTime()) / 1000);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import type {
   ExtremesResponse,
   PositionOptions,
 } from "./types.js";
-import { approximateTideHeightAt } from "./calculations.js";
+import { approximateTideHeightAt, tideStateAt, timeToNextExtreme } from "./calculations.js";
 import FileCache from "./cache.js";
 import createSources from "./sources/index.js";
 import { createAdapterRoutes } from "./routes.js";
@@ -222,6 +222,9 @@ export default function (app: SignalKApp): Plugin {
         .filter(({ time }) => time >= now)
         .slice(0, 2);
 
+      const state = tideStateAt(lastForecast.extremes, now);
+      const secondsToNextExtreme = timeToNextExtreme(lastForecast.extremes, now);
+
       const delta: Delta = {
         context: ("vessels." + app.selfId) as Context,
         updates: [
@@ -236,12 +239,33 @@ export default function (app: SignalKApp): Plugin {
                 path: "environment.tide.heightNow" as Path,
                 value: approximateTideHeightAt(lastForecast.extremes, now),
               },
+              // Omitted (not null) when the forecast has no upcoming extreme,
+              // matching how the nextTides flatMap below goes empty.
+              ...(state !== null
+                ? [{ path: "environment.tide.state" as Path, value: state }]
+                : []),
+              ...(secondsToNextExtreme !== null
+                ? [{ path: "environment.tide.timeToNextExtreme" as Path, value: secondsToNextExtreme }]
+                : []),
               ...nextTides.flatMap(({ label, time, level }) => {
                 return [
                   { path: `environment.tide.height${label}` as Path, value: level },
                   { path: `environment.tide.time${label}` as Path, value: time.toISOString() },
                 ];
               }),
+            ],
+          },
+          {
+            timestamp: now.toISOString() as Timestamp,
+            meta: [
+              {
+                path: "environment.tide.state" as Path,
+                value: { description: "Tide trend at the current position: rising or falling" },
+              },
+              {
+                path: "environment.tide.timeToNextExtreme" as Path,
+                value: { units: "s", description: "Seconds until the next tide extreme (high or low water)" },
+              },
             ],
           },
         ],

--- a/test/calculations.test.ts
+++ b/test/calculations.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { tideStateAt, timeToNextExtreme, approximateTideHeightAt } from "../src/calculations.js";
+import type { Extreme } from "../src/types.js";
+
+const extreme = (time: string, level: number, high: boolean): Extreme => ({
+  time: new Date(time),
+  level,
+  high,
+  low: !high,
+  label: high ? "High" : "Low",
+});
+
+// One semidiurnal day in Boundary Pass-ish shape
+const extremes: Extreme[] = [
+  extreme("2026-06-05T00:00:00Z", 3.2, true),
+  extreme("2026-06-05T06:12:00Z", 0.4, false),
+  extreme("2026-06-05T12:30:00Z", 3.4, true),
+  extreme("2026-06-05T18:45:00Z", 0.2, false),
+];
+
+describe("tideStateAt", () => {
+  it("is falling when the next extreme is a Low", () => {
+    expect(tideStateAt(extremes, new Date("2026-06-05T03:00:00Z"))).toBe("falling");
+  });
+
+  it("is rising when the next extreme is a High", () => {
+    expect(tideStateAt(extremes, new Date("2026-06-05T09:00:00Z"))).toBe("rising");
+  });
+
+  it("reads as the extreme's own type at the exact extreme moment", () => {
+    // Intentional boundary: at the instant of low water the Low itself is
+    // still "next" (time >= now), so the state reads "falling" for that tick
+    // and flips to "rising" on the next one.
+    expect(tideStateAt(extremes, new Date("2026-06-05T06:12:00Z"))).toBe("falling");
+  });
+
+  it("handles unsorted input", () => {
+    const shuffled = [extremes[2], extremes[0], extremes[3], extremes[1]];
+    expect(tideStateAt(shuffled, new Date("2026-06-05T03:00:00Z"))).toBe("falling");
+  });
+
+  it("returns null when there is no upcoming extreme", () => {
+    expect(tideStateAt(extremes, new Date("2026-06-05T19:00:00Z"))).toBeNull();
+    expect(tideStateAt([], new Date("2026-06-05T03:00:00Z"))).toBeNull();
+  });
+});
+
+describe("timeToNextExtreme", () => {
+  it("returns seconds until the next extreme", () => {
+    // 03:00 -> 06:12 Low = 3h12m
+    expect(timeToNextExtreme(extremes, new Date("2026-06-05T03:00:00Z"))).toBe(11520);
+    // 12:00 -> 12:30 High = 30m
+    expect(timeToNextExtreme(extremes, new Date("2026-06-05T12:00:00Z"))).toBe(1800);
+  });
+
+  it("returns 0 exactly at an extreme", () => {
+    expect(timeToNextExtreme(extremes, new Date("2026-06-05T06:12:00Z"))).toBe(0);
+  });
+
+  it("stays above 0 until the extreme is reached (rounds up)", () => {
+    // 400ms before the Low: Math.round would report 0 early
+    expect(timeToNextExtreme(extremes, new Date("2026-06-05T06:11:59.600Z"))).toBe(1);
+  });
+
+  it("returns null when there is no upcoming extreme", () => {
+    expect(timeToNextExtreme(extremes, new Date("2026-06-05T19:00:00Z"))).toBeNull();
+    expect(timeToNextExtreme([], new Date("2026-06-05T03:00:00Z"))).toBeNull();
+  });
+});
+
+describe("approximateTideHeightAt", () => {
+  it("interpolates the midpoint between extremes with sine easing", () => {
+    // Halfway 06:12 -> 12:30 is 09:21; easeSine(0.5) = 0.5 -> mean of 0.4 and 3.4
+    expect(approximateTideHeightAt(extremes, new Date("2026-06-05T09:21:00Z"))).toBeCloseTo(1.9, 3);
+  });
+
+  it("returns the extreme's value exactly at an extreme", () => {
+    expect(approximateTideHeightAt(extremes, new Date("2026-06-05T06:12:00Z"))).toBe(0.4);
+  });
+
+  it("throws when data is missing before or after", () => {
+    expect(() => approximateTideHeightAt(extremes, new Date("2026-06-04T00:00:00Z"))).toThrow();
+    expect(() => approximateTideHeightAt(extremes, new Date("2026-06-06T00:00:00Z"))).toThrow();
+  });
+});


### PR DESCRIPTION
Takes you up on the "PRs welcome" from #5. Two new paths in the per-minute delta:

* `environment.tide.state` — `rising` / `falling`, from the next extreme's type
* `environment.tide.timeToNextExtreme` — seconds until the next high/low water, with `units: "s"` meta so KIP renders it as a duration

I renamed `timeUntilSlack` from the original ask: with height extremes we can't honestly know slack *current* timing (around here in the Salish Sea slack can lag high water by a lot), so `timeToNextExtreme` says what it actually is. Both paths are omitted when the forecast has no upcoming extremes, same as the existing height/time pairs.

A few things along the way:

* First test suite for the repo — vitest (dev-only, rides the vite toolchain you already have), 11 tests over the calculation functions, plus a CI test job.
* Drive-by fix: `approximateTideHeightAt` returned NaN exactly at an extreme (0/0 in the progress math) — `heightNow` went NaN for that tick.
* One quirk worth knowing: at the exact instant of an extreme, state reads as that extreme's own type (`falling` with 0s at low water) for one tick, then flips. Documented in the jsdoc + pinned by a test.
* Known and left alone: `approximateTideHeightAt` still throws on a fully stale forecast and `updateTides` has no try/catch — pre-existing, felt like scope creep to fix here. Can do a follow-up if you want.
* Meta goes out with every delta — idempotent, keeps late subscribers correct. Easy to move to emit-once-at-start if you'd rather.

Stacked on #76 (the first commit here is that fix) — I'll rebase onto main once it merges.

Closes #5
