### PR TITLE
Remove the app.debug.enabled workaround (server-api 2.28.0 types it now)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@neaps/api": "^0.5.1",
     "@neaps/react": "^0.1.0",
-    "@signalk/server-api": "^2.0",
+    "@signalk/server-api": "^2.28.0",
     "express": "^4.0",
     "neaps": "^0.7.0",
     "react": "^19.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { Context, Delta, Path, Plugin, Position, Timestamp } from "@signalk/server-api";
+import { Context, Delta, Path, Plugin, Position, ServerAPI, Timestamp } from "@signalk/server-api";
 import { RequestHandler } from "express";
 import { createRoutes } from "@neaps/api";
 import { getExtremesPrediction, getWaterLevelAtTime } from "neaps";
-import type { SignalKApp } from "./types.js";
 import { tideStateAt, timeToNextExtreme } from "./calculations.js";
 import FileCache from "./cache.js";
 import { withVesselPosition } from "./middleware.js";
@@ -30,7 +29,7 @@ type Forecast = ReturnType<typeof getExtremesPrediction>;
 const UPDATE_INTERVAL = 60 * 1000; // 1 minute
 const API_PATH = "/signalk/v2/api/tides";
 
-export default function (app: SignalKApp): Plugin {
+export default function (app: ServerAPI): Plugin {
   let unsubscribes: (() => void)[] = [];
   let activeRouter: RequestHandler | null = null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,0 @@
-import { ServerAPI } from "@signalk/server-api";
-
-// Workaround pending an upstream type fix in @signalk/server-api: at runtime
-// `app.debug` is a debug-module instance with an `.enabled` property, but
-// ServerAPI types it as a bare function. Omit the upstream `debug` member
-// before intersecting so the property doesn't collapse to `never`.
-export type SignalKApp = Omit<ServerAPI, "debug"> & {
-  debug: ServerAPI["debug"] & { enabled: boolean };
-};


### PR DESCRIPTION
#76 added a little `SignalKApp` type to work around `@signalk/server-api` typing `app.debug` as a bare function — we needed `.enabled` to gate the verbose delta logging.

That's fixed upstream now: `@signalk/server-api` 2.28.0 types `debug` as a callable with `.enabled` (via SignalK/signalk-server#2758), so the workaround can go. This drops `SignalKApp` and uses `ServerAPI` directly at the call sites, and bumps the `@signalk/server-api` floor to `^2.28.0`.

Tested: `tsc -b`, `npm run build`, `npm run lint`, and the node + browser suites all pass.