### PR TITLE
Add configurable default tide station

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ It publishes the following [tide data](https://signalk.org/specification/1.7.0/d
 
 ### Tides API
 
-The plugin mounts the [Neaps API](https://github.com/neaps/neaps) at `/signalk/v2/api/tides`, which serves station search, extremes, and timeline predictions. The synthetic station `vessel/current` resolves to the nearest station to the vessel:
+The plugin mounts the [Neaps API](https://github.com/neaps/neaps) at `/signalk/v2/api/tides`, which serves station search, extremes, and timeline predictions. The synthetic station `vessel/default` resolves to the configured default station, or the nearest station to the vessel when none is set:
 
 ```
-$ curl http://localhost:3000/signalk/v2/api/tides/stations/vessel/current/extremes
+$ curl http://localhost:3000/signalk/v2/api/tides/stations/vessel/default/extremes
 ```
 
 ### Tides resource

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -3,7 +3,7 @@ import './App.css'
 import { TideStation } from '@neaps/react';
 import { useUnitPreferences } from './hooks/useUnitPreferences'
 
-const VESSEL_STATION_ID = 'vessel/current';
+const VESSEL_STATION_ID = 'vessel/default';
 const { VITE_SIGNALK_URL = window.location.toString() } = import.meta.env;
 const API_BASE_URL = new URL("/signalk/v2/api", VITE_SIGNALK_URL).toString();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,17 @@
 import { Context, Delta, Path, Plugin, Position, ServerAPI, Timestamp } from "@signalk/server-api";
 import { RequestHandler } from "express";
 import { createRoutes } from "@neaps/api";
-import { getExtremesPrediction, getWaterLevelAtTime } from "neaps";
+import { findStation, nearestStation, stationsNear } from "neaps";
 import { tideStateAt, timeToNextExtreme } from "./calculations.js";
 import FileCache from "./cache.js";
 import { withVesselPosition } from "./middleware.js";
 
-type Forecast = ReturnType<typeof getExtremesPrediction>;
+type Predictor = ReturnType<typeof findStation>;
+type Forecast = ReturnType<Predictor["getExtremesPrediction"]>;
+
+interface Config {
+  defaultStation?: string;
+}
 
 // Recompute and republish on a fixed interval. Predictions are computed locally
 // by neaps, so this is cheap and needs no configuration.
@@ -32,6 +37,8 @@ const API_PATH = "/signalk/v2/api/tides";
 export default function (app: ServerAPI): Plugin {
   let unsubscribes: (() => void)[] = [];
   let activeRouter: RequestHandler | null = null;
+  let lastPosition: Position | null = null;
+  let config: Config = {};
 
   // Mount forwarding middleware once (Express doesn't support unmounting)
   // @ts-expect-error: app is an Express app at runtime
@@ -51,7 +58,16 @@ export default function (app: ServerAPI): Plugin {
     schema: () => ({
       title: "Tides",
       type: "object",
-      properties: {},
+      properties: {
+        defaultStation: {
+          type: "string",
+          title: "Default tide station",
+          description:
+            "Use the closest station to the vessel's current position, or pick a default nearby station.",
+          default: "auto",
+          oneOf: defaultStationOptions(),
+        },
+      },
     }),
     start,
     stop() {
@@ -61,17 +77,56 @@ export default function (app: ServerAPI): Plugin {
     },
   };
 
-  async function start() {
+  function defaultStationOptions(): { const: string; title: string }[] {
+    const options = [{ const: "auto", title: "Closest station" }];
+
+    if (lastPosition) {
+      for (const station of stationsNear({ ...lastPosition, maxResults: 10 })) {
+        options.push({ const: station.id, title: stationTitle(station) });
+      }
+    }
+
+    // Keep the saved station selectable even when it is not in the nearby
+    // list, so opening the settings far from it (or before a position fix)
+    // cannot clobber it on save.
+    const saved = savedDefaultStation();
+    if (saved && saved !== "auto" && !options.some((o) => o.const === saved)) {
+      let title = saved;
+      try {
+        title = stationTitle(findStation(saved));
+      } catch {
+        // Unknown id: keep the raw value as the label
+      }
+      options.splice(1, 0, { const: saved, title });
+    }
+
+    return options;
+  }
+
+  function savedDefaultStation(): string | undefined {
+    try {
+      const saved = app.readPluginOptions() as {
+        configuration?: Config | null;
+      };
+      return saved?.configuration?.defaultStation;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function start(options?: object) {
     app.debug("Starting tides");
+    config = (options ?? {}) as Config;
 
     let lastForecast: Forecast | null = null;
-    let lastPosition: Position | null = null;
     const cache = new FileCache(app.getDataDirPath());
 
-    // Mount the Neaps API, with vessel/current resolved to the nearest station.
+    // Mount the Neaps API, with vessel/default resolved to the configured
+    // default station (or the nearest one).
     activeRouter = withVesselPosition(
       createRoutes({ prefix: API_PATH }),
       () => lastPosition,
+      () => config.defaultStation ?? null,
     );
 
     // Register tide predictions as a resource provider
@@ -79,11 +134,11 @@ export default function (app: ServerAPI): Plugin {
       type: "tides",
       methods: {
         async listResources() {
-          if (!lastPosition) throw new Error("No position available");
-          return forecastFor(lastPosition) as unknown as Record<
-            string,
-            unknown
-          >;
+          const predictor = resolvePredictor();
+          if (!predictor) {
+            throw new Error("No position or default station available");
+          }
+          return forecastFor(predictor) as unknown as Record<string, unknown>;
         },
         getResource(): never {
           throw new Error("Not implemented");
@@ -115,11 +170,29 @@ export default function (app: ServerAPI): Plugin {
       updatePosition,
     );
 
-    function forecastFor(position: Position): Forecast {
+    function resolvePredictor(): Predictor | null {
+      if (config.defaultStation && config.defaultStation !== "auto") {
+        try {
+          return findStation(config.defaultStation);
+        } catch {
+          app.error(
+            `Configured tide station not found: ${config.defaultStation}`,
+          );
+        }
+      }
+      if (lastPosition) {
+        try {
+          return nearestStation(lastPosition);
+        } catch {
+          app.error("No tide station found near vessel position");
+        }
+      }
+      return null;
+    }
+
+    function forecastFor(predictor: Predictor): Forecast {
       const now = new Date();
-      return getExtremesPrediction({
-        latitude: position.latitude,
-        longitude: position.longitude,
+      return predictor.getExtremesPrediction({
         start: now,
         end: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
       });
@@ -139,17 +212,21 @@ export default function (app: ServerAPI): Plugin {
         lastPosition = (await cache.get("position")) as Position;
       }
 
-      if (lastPosition) updateForecast();
+      // A configured default station predicts without a position
+      updateForecast();
     }
 
     function updateForecast() {
-      if (!lastPosition) {
-        app.debug("No position available, cannot compute tide data");
+      const predictor = resolvePredictor();
+      if (!predictor) {
+        app.debug(
+          "No position or default station available, cannot compute tide data",
+        );
         return;
       }
 
       try {
-        lastForecast = forecastFor(lastPosition);
+        lastForecast = forecastFor(predictor);
         app.setPluginStatus("Updated tide forecast");
         updateTides();
       } catch (e: unknown) {
@@ -161,20 +238,22 @@ export default function (app: ServerAPI): Plugin {
     }
 
     function updateTides(now = new Date()) {
-      if (!lastForecast || !lastPosition) return;
+      if (!lastForecast) return;
+      const predictor = resolvePredictor();
+      if (!predictor) return;
+
       // Get the next two upcoming extremes
       const nextTides = lastForecast.extremes
         .filter(({ time }) => time >= now)
         .slice(0, 2);
 
-      const heightNow = getWaterLevelAtTime({
-        latitude: lastPosition.latitude,
-        longitude: lastPosition.longitude,
-        time: now,
-      }).level;
+      const heightNow = predictor.getWaterLevelAtTime({ time: now }).level;
 
       const state = tideStateAt(lastForecast.extremes, now);
-      const secondsToNextExtreme = timeToNextExtreme(lastForecast.extremes, now);
+      const secondsToNextExtreme = timeToNextExtreme(
+        lastForecast.extremes,
+        now,
+      );
 
       const delta: Delta = {
         context: ("vessels." + app.selfId) as Context,
@@ -196,7 +275,12 @@ export default function (app: ServerAPI): Plugin {
                 ? [{ path: "environment.tide.state" as Path, value: state }]
                 : []),
               ...(secondsToNextExtreme !== null
-                ? [{ path: "environment.tide.timeToNextExtreme" as Path, value: secondsToNextExtreme }]
+                ? [
+                    {
+                      path: "environment.tide.timeToNextExtreme" as Path,
+                      value: secondsToNextExtreme,
+                    },
+                  ]
                 : []),
               ...nextTides.flatMap(({ label, time, level }) => {
                 return [
@@ -217,11 +301,18 @@ export default function (app: ServerAPI): Plugin {
             meta: [
               {
                 path: "environment.tide.state" as Path,
-                value: { description: "Tide trend at the current position: rising or falling" },
+                value: {
+                  description:
+                    "Tide trend at the current position: rising or falling",
+                },
               },
               {
                 path: "environment.tide.timeToNextExtreme" as Path,
-                value: { units: "s", description: "Seconds until the next tide extreme (high or low water)" },
+                value: {
+                  units: "s",
+                  description:
+                    "Seconds until the next tide extreme (high or low water)",
+                },
               },
             ],
           },
@@ -243,4 +334,11 @@ export default function (app: ServerAPI): Plugin {
   }
 
   return plugin;
+}
+
+function stationTitle(station: Predictor): string {
+  const where = [station.region, station.country].filter(Boolean).join(", ");
+  const distance =
+    station.distance != null ? ` — ${station.distance.toFixed(1)} km` : "";
+  return `${station.name}${where ? ` (${where})` : ""}${distance}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,10 @@ export default function (app: ServerAPI): Plugin {
     app.debug("Starting tides");
     config = (options ?? {}) as Config;
 
+    // Keep the forecast and the predictor that produced it together, so the
+    // extremes and the current height are always read from the same station.
     let lastForecast: Forecast | null = null;
+    let lastPredictor: Predictor | null = null;
     const cache = new FileCache(app.getDataDirPath());
 
     // Mount the Neaps API, with vessel/default resolved to the configured
@@ -222,11 +225,14 @@ export default function (app: ServerAPI): Plugin {
         app.debug(
           "No position or default station available, cannot compute tide data",
         );
+        lastForecast = null;
+        lastPredictor = null;
         return;
       }
 
       try {
         lastForecast = forecastFor(predictor);
+        lastPredictor = predictor;
         app.setPluginStatus("Updated tide forecast");
         updateTides();
       } catch (e: unknown) {
@@ -238,16 +244,14 @@ export default function (app: ServerAPI): Plugin {
     }
 
     function updateTides(now = new Date()) {
-      if (!lastForecast) return;
-      const predictor = resolvePredictor();
-      if (!predictor) return;
+      if (!lastForecast || !lastPredictor) return;
 
       // Get the next two upcoming extremes
       const nextTides = lastForecast.extremes
         .filter(({ time }) => time >= now)
         .slice(0, 2);
 
-      const heightNow = predictor.getWaterLevelAtTime({ time: now }).level;
+      const heightNow = lastPredictor.getWaterLevelAtTime({ time: now }).level;
 
       const state = tideStateAt(lastForecast.extremes, now);
       const secondsToNextExtreme = timeToNextExtreme(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,52 +2,66 @@
  * Middleware for handling vessel position queries and redirects
  */
 import { RequestHandler } from 'express';
-import { nearestStation } from 'neaps';
+import { findStation, nearestStation } from 'neaps';
 import type { Position } from '@signalk/server-api';
 
 /**
- * Middleware that handles vessel/current station endpoints by redirecting to
- * the nearest real station, and injects the default vessel position for
- * location-based queries.
+ * Middleware that resolves the vessel/default station alias and bare
+ * location-based queries (/extremes, /timeline) against the configured default
+ * station, falling back to the station nearest the vessel's position when no
+ * default is set.
  */
 export function withVesselPosition(
   router: RequestHandler,
   getPosition: () => Position | null,
+  getDefaultStationId?: () => string | null,
 ): RequestHandler {
   return (req, res, next) => {
-    const isVesselCurrentPath = /^\/stations\/vessel\/current(?:\/|$)/.test(
-      req.path,
-    );
+    // HTTP 303 See Other: the response can be found under a different URI
+    const redirect = (toPath: string) =>
+      res.redirect(303, `${req.baseUrl}${toPath}`);
 
-    // Handle vessel/current station endpoints by redirecting to the nearest real station
-    if (isVesselCurrentPath) {
+    // The configured default station, or null when unset, "auto", or stale.
+    const defaultStation = (): { id: string } | null => {
+      const id = getDefaultStationId?.();
+      if (!id || id === "auto") return null;
+      try {
+        return findStation(id);
+      } catch {
+        return null; // stale or invalid saved id: fall back to position
+      }
+    };
+
+    // Redirect the vessel/default alias to the configured (or nearest) station.
+    if (/^\/stations\/vessel\/default(?:\/|$)/.test(req.path)) {
+      const toStation = (station: { id: string }) =>
+        redirect(
+          req.url.replace(
+            /^\/stations\/vessel\/default\b/,
+            `/stations/${station.id}`,
+          ),
+        );
+
+      // A configured default station resolves without a position
+      const station = defaultStation();
+      if (station) return toStation(station);
+
       const pos = getPosition();
-
       if (!pos) {
-        return res.status(503).json({
-          message: "Vessel position not available",
-        });
+        return res.status(503).json({ message: "Vessel position not available" });
       }
 
       try {
-        const station = nearestStation({
+        const nearest = nearestStation({
           latitude: pos.latitude,
           longitude: pos.longitude,
         });
 
-        if (!station) {
-          return res.status(404).json({
-            message: "No nearby stations found",
-          });
+        if (!nearest) {
+          return res.status(404).json({ message: "No nearby stations found" });
         }
 
-        const path = req.url.replace(
-          /^\/stations\/vessel\/current\b/,
-          `/stations/${station.id}`,
-        );
-
-        // HTTP 303 See Other: the response can be found under a different URI
-        return res.redirect(303, `${req.baseUrl}${path}`);
+        return toStation(nearest);
       } catch {
         return res.status(500).json({
           message: "Failed to find nearest station",
@@ -55,10 +69,21 @@ export function withVesselPosition(
       }
     }
 
-    // Inject default position for location-based queries
+    // Bare location-based queries: redirect to the configured station when set,
+    // otherwise inject the vessel position so neaps uses the nearest station.
     const isLocationQueryPath =
       req.path === "/extremes" || req.path === "/timeline";
     if (isLocationQueryPath && !req.query.latitude && !req.query.longitude) {
+      const station = defaultStation();
+      if (station) {
+        return redirect(
+          req.url.replace(
+            /^\/(extremes|timeline)\b/,
+            `/stations/${station.id}/$1`,
+          ),
+        );
+      }
+
       const pos = getPosition();
       if (pos) {
         req.query.latitude = String(pos.latitude);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,9 @@
 /**
  * Middleware for handling vessel position queries and redirects
  */
-import { RequestHandler } from 'express';
-import { findStation, nearestStation } from 'neaps';
-import type { Position } from '@signalk/server-api';
+import { RequestHandler } from "express";
+import { findStation, nearestStation } from "neaps";
+import type { Position } from "@signalk/server-api";
 
 /**
  * Middleware that resolves the vessel/default station alias and bare

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -5,12 +5,22 @@ import type { Request, Response, Router } from 'express';
 import type { Position } from '@signalk/server-api';
 import { withVesselPosition } from '../src/middleware.js';
 
-// Mock neaps' nearestStation — the middleware only reads `.id` off the result.
-vi.mock('neaps', () => ({ nearestStation: vi.fn() }));
-const { nearestStation } = await import('neaps');
+// Mock neaps' station lookups — the middleware only reads `.id` off the result.
+vi.mock('neaps', () => ({ nearestStation: vi.fn(), findStation: vi.fn() }));
+const { nearestStation, findStation } = await import('neaps');
 
 function mockNearest(id: string | null) {
   vi.mocked(nearestStation).mockReturnValue((id ? { id } : null) as never);
+}
+
+function mockFind(id: string | null) {
+  if (id) {
+    vi.mocked(findStation).mockReturnValue({ id } as never);
+  } else {
+    vi.mocked(findStation).mockImplementation(() => {
+      throw new Error(`Station not found`);
+    });
+  }
 }
 
 describe('withVesselPosition middleware', () => {
@@ -24,19 +34,25 @@ describe('withVesselPosition middleware', () => {
     vi.clearAllMocks();
   });
 
-  function buildApp(getPosition: () => Position | null) {
+  function buildApp(
+    getPosition: () => Position | null,
+    getDefaultStationId?: () => string | null,
+  ) {
     const app = express();
-    app.use('/signalk/v2/api/tides', withVesselPosition(mockRouter, getPosition));
+    app.use(
+      '/signalk/v2/api/tides',
+      withVesselPosition(mockRouter, getPosition, getDefaultStationId),
+    );
     return app;
   }
 
   const atSF = () => ({ latitude: 37.7749, longitude: -122.4194 } as Position);
 
-  describe('vessel/current station requests', () => {
+  describe('vessel/default station requests', () => {
     it('returns 303 redirect to nearest station', async () => {
       mockNearest('noaa/9414290');
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current')
+        .get('/signalk/v2/api/tides/stations/vessel/default')
         .expect(303);
 
       expect(nearestStation).toHaveBeenCalledWith({
@@ -49,7 +65,7 @@ describe('withVesselPosition middleware', () => {
     it('preserves query parameters in redirect', async () => {
       mockNearest('noaa/9414290');
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current/extremes?start=2025-01-01&end=2025-01-08')
+        .get('/signalk/v2/api/tides/stations/vessel/default/extremes?start=2025-01-01&end=2025-01-08')
         .expect(303);
 
       expect(response.headers.location).toBe(
@@ -60,7 +76,7 @@ describe('withVesselPosition middleware', () => {
     it('preserves path suffix in redirect', async () => {
       mockNearest('noaa/9414290');
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current/timeline')
+        .get('/signalk/v2/api/tides/stations/vessel/default/timeline')
         .expect(303);
 
       expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/noaa/9414290/timeline');
@@ -69,7 +85,7 @@ describe('withVesselPosition middleware', () => {
     it('handles compound station IDs', async () => {
       mockNearest('worldtides/US/San_Francisco');
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current')
+        .get('/signalk/v2/api/tides/stations/vessel/default')
         .expect(303);
 
       expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/worldtides/US/San_Francisco');
@@ -77,7 +93,7 @@ describe('withVesselPosition middleware', () => {
 
     it('returns 503 when vessel position unavailable', async () => {
       const response = await request(buildApp(() => null))
-        .get('/signalk/v2/api/tides/stations/vessel/current')
+        .get('/signalk/v2/api/tides/stations/vessel/default')
         .expect(503);
 
       expect(nearestStation).not.toHaveBeenCalled();
@@ -87,7 +103,7 @@ describe('withVesselPosition middleware', () => {
     it('returns 404 when no nearby stations found', async () => {
       mockNearest(null);
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current')
+        .get('/signalk/v2/api/tides/stations/vessel/default')
         .expect(404);
 
       expect(response.body).toEqual({ message: 'No nearby stations found' });
@@ -98,10 +114,82 @@ describe('withVesselPosition middleware', () => {
         throw new Error('boom');
       });
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current')
+        .get('/signalk/v2/api/tides/stations/vessel/default')
         .expect(500);
 
       expect(response.body).toEqual({ message: 'Failed to find nearest station' });
+    });
+  });
+
+  describe('default station', () => {
+    it('redirects vessel/default to the configured station', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(atSF, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/stations/vessel/default')
+        .expect(303);
+
+      expect(findStation).toHaveBeenCalledWith('noaa/9410230');
+      expect(nearestStation).not.toHaveBeenCalled();
+      expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/noaa/9410230');
+    });
+
+    it('preserves path suffix and query parameters in redirect', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(atSF, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/stations/vessel/default/extremes?start=2025-01-01&end=2025-01-08')
+        .expect(303);
+
+      expect(response.headers.location).toBe(
+        '/signalk/v2/api/tides/stations/noaa/9410230/extremes?start=2025-01-01&end=2025-01-08',
+      );
+    });
+
+    it('resolves the configured station without a vessel position', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(() => null, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/stations/vessel/default')
+        .expect(303);
+
+      expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/noaa/9410230');
+    });
+
+    it('uses the nearest station when set to "auto"', async () => {
+      mockNearest('noaa/9414290');
+      const response = await request(buildApp(atSF, () => 'auto'))
+        .get('/signalk/v2/api/tides/stations/vessel/default')
+        .expect(303);
+
+      expect(findStation).not.toHaveBeenCalled();
+      expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/noaa/9414290');
+    });
+
+    it('uses the nearest station when unset', async () => {
+      mockNearest('noaa/9414290');
+      const response = await request(buildApp(atSF, () => null))
+        .get('/signalk/v2/api/tides/stations/vessel/default')
+        .expect(303);
+
+      expect(findStation).not.toHaveBeenCalled();
+      expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/noaa/9414290');
+    });
+
+    it('falls back to the nearest station when the configured station is not found', async () => {
+      mockFind(null);
+      mockNearest('noaa/9414290');
+      const response = await request(buildApp(atSF, () => 'stale/id'))
+        .get('/signalk/v2/api/tides/stations/vessel/default')
+        .expect(303);
+
+      expect(response.headers.location).toBe('/signalk/v2/api/tides/stations/noaa/9414290');
+    });
+
+    it('returns 503 when the configured station is not found and no position is available', async () => {
+      mockFind(null);
+      const response = await request(buildApp(() => null, () => 'stale/id'))
+        .get('/signalk/v2/api/tides/stations/vessel/default')
+        .expect(503);
+
+      expect(response.body).toEqual({ message: 'Vessel position not available' });
     });
   });
 
@@ -150,32 +238,97 @@ describe('withVesselPosition middleware', () => {
       expect(response.body.query.latitude).toBeUndefined();
       expect(response.body.query.longitude).toBeUndefined();
     });
+
+    it('redirects /extremes to the configured station', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(atSF, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/extremes?start=2025-01-01&end=2025-01-08')
+        .expect(303);
+
+      expect(nearestStation).not.toHaveBeenCalled();
+      expect(response.headers.location).toBe(
+        '/signalk/v2/api/tides/stations/noaa/9410230/extremes?start=2025-01-01&end=2025-01-08',
+      );
+    });
+
+    it('redirects /timeline to the configured station', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(atSF, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/timeline')
+        .expect(303);
+
+      expect(response.headers.location).toBe(
+        '/signalk/v2/api/tides/stations/noaa/9410230/timeline',
+      );
+    });
+
+    it('redirects /extremes to the configured station without a position', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(() => null, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/extremes')
+        .expect(303);
+
+      expect(response.headers.location).toBe(
+        '/signalk/v2/api/tides/stations/noaa/9410230/extremes',
+      );
+    });
+
+    it('injects position for /extremes when set to "auto"', async () => {
+      const response = await request(buildApp(atSF, () => 'auto'))
+        .get('/signalk/v2/api/tides/extremes')
+        .expect(200);
+
+      expect(findStation).not.toHaveBeenCalled();
+      expect(response.body.query.latitude).toBe('37.7749');
+      expect(response.body.query.longitude).toBe('-122.4194');
+    });
+
+    it('injects position for /extremes when the configured station is stale', async () => {
+      mockFind(null);
+      const response = await request(buildApp(atSF, () => 'stale/id'))
+        .get('/signalk/v2/api/tides/extremes')
+        .expect(200);
+
+      expect(response.body.query.latitude).toBe('37.7749');
+      expect(response.body.query.longitude).toBe('-122.4194');
+    });
+
+    it('does not redirect /extremes when explicit coordinates are given', async () => {
+      mockFind('noaa/9410230');
+      const response = await request(buildApp(atSF, () => 'noaa/9410230'))
+        .get('/signalk/v2/api/tides/extremes?latitude=40.7128&longitude=-74.0060')
+        .expect(200);
+
+      expect(findStation).not.toHaveBeenCalled();
+      expect(response.body.query.latitude).toBe('40.7128');
+      expect(response.body.query.longitude).toBe('-74.0060');
+    });
   });
 
   describe('path detection', () => {
-    it('detects vessel/current at the root', async () => {
+    it('detects vessel/default at the root', async () => {
       mockNearest('noaa/9414290');
       await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current')
+        .get('/signalk/v2/api/tides/stations/vessel/default')
         .expect(303);
       expect(nearestStation).toHaveBeenCalledTimes(1);
     });
 
-    it('detects vessel/current with trailing slash', async () => {
+    it('detects vessel/default with trailing slash', async () => {
       mockNearest('noaa/9414290');
       await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current/')
+        .get('/signalk/v2/api/tides/stations/vessel/default/')
         .expect(303);
       expect(nearestStation).toHaveBeenCalledTimes(1);
     });
 
-    it('does not match partial vessel/current paths', async () => {
+    it('does not match partial vessel/default paths', async () => {
       const response = await request(buildApp(atSF))
-        .get('/signalk/v2/api/tides/stations/vessel/current-not-this')
+        .get('/signalk/v2/api/tides/stations/vessel/default-not-this')
         .expect(200);
 
       expect(nearestStation).not.toHaveBeenCalled();
-      expect(response.body.path).toBe('/stations/vessel/current-not-this');
+      expect(response.body.path).toBe('/stations/vessel/default-not-this');
     });
   });
 });

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Plugin, Position, ServerAPI } from "@signalk/server-api";
+import { nearestStation, stationsNear } from "neaps";
+import createPlugin from '../src/index.js';
+
+const SF: Position = { latitude: 37.7749, longitude: -122.4194 };
+
+interface StationOption {
+  const: string;
+  title: string;
+}
+
+function stationOptions(plugin: Plugin): StationOption[] {
+  const schema = (plugin.schema as () => never)() as {
+    properties: { defaultStation: { oneOf: StationOption[] } };
+  };
+  return schema.properties.defaultStation.oneOf;
+}
+
+function buildApp(configuration?: { defaultStation?: string }) {
+  let onPositionDelta: (() => Promise<void>) | undefined;
+
+  const app = {
+    debug: Object.assign(vi.fn(), { enabled: false }),
+    error: vi.fn(),
+    setPluginStatus: vi.fn(),
+    setPluginError: vi.fn(),
+    selfId: 'urn:mrn:imo:mmsi:000000000',
+    use: vi.fn(),
+    getDataDirPath: () => mkdtempSync(join(tmpdir(), 'signalk-tides-test-')),
+    readPluginOptions: vi.fn(() => ({ configuration })),
+    registerResourceProvider: vi.fn(),
+    handleMessage: vi.fn(),
+    getSelfPath: vi.fn(),
+    subscriptionmanager: {
+      subscribe: vi.fn(
+        (
+          _subscription: unknown,
+          _unsubscribes: unknown,
+          _onError: unknown,
+          onDelta: () => Promise<void>,
+        ) => {
+          onPositionDelta = onDelta;
+        },
+      ),
+    },
+  };
+
+  return {
+    app: app as unknown as ServerAPI,
+    // Simulates a navigation.position delta arriving
+    async sendPosition(position: Position) {
+      app.getSelfPath.mockReturnValue(position);
+      await onPositionDelta?.();
+    },
+  };
+}
+
+function publishedStationName(app: ServerAPI): unknown {
+  const delta = vi.mocked(app.handleMessage).mock.calls.at(-1)![1];
+  return (delta.updates ?? [])
+    .flatMap((u) => ("values" in u ? u.values : []))
+    .find((v) => v.path === "environment.tide.stationName")?.value;
+}
+
+describe('plugin', () => {
+  let plugin: Plugin | undefined;
+
+  afterEach(() => {
+    plugin?.stop?.();
+    plugin = undefined;
+  });
+
+  describe('schema', () => {
+    it('offers only "auto" before a position is known', () => {
+      const { app } = buildApp();
+      plugin = createPlugin(app);
+
+      expect(stationOptions(plugin)).toEqual([
+        { const: 'auto', title: 'Closest station' },
+      ]);
+    });
+
+    it('lists nearby stations once a position is known', async () => {
+      const { app, sendPosition } = buildApp();
+      plugin = createPlugin(app);
+      await plugin.start({}, () => {});
+      await sendPosition(SF);
+
+      const options = stationOptions(plugin);
+      const nearest = nearestStation(SF);
+
+      expect(options[0].const).toBe('auto');
+      expect(options.length).toBeGreaterThan(1);
+      expect(options.map((o) => o.const)).toContain(nearest.id);
+      const nearestOption = options.find((o) => o.const === nearest.id)!;
+      expect(nearestOption.title).toContain(nearest.name);
+      expect(nearestOption.title).toMatch(/km$/);
+    });
+
+    it('keeps a saved station selectable when it is not nearby', () => {
+      const station = nearestStation({ latitude: 42.35, longitude: -71.05 }); // Boston, far from SF
+      const { app } = buildApp({ defaultStation: station.id });
+      plugin = createPlugin(app);
+
+      const options = stationOptions(plugin);
+      expect(options[0].const).toBe('auto');
+      expect(options[1].const).toBe(station.id);
+      expect(options[1].title).toContain(station.name);
+    });
+
+    it('keeps a saved station with an unknown id selectable', () => {
+      const { app } = buildApp({ defaultStation: 'stale/id' });
+      plugin = createPlugin(app);
+
+      expect(stationOptions(plugin)[1]).toEqual({
+        const: 'stale/id',
+        title: 'stale/id',
+      });
+    });
+  });
+
+  describe('deltas', () => {
+    it('publishes the nearest station by default', async () => {
+      const { app, sendPosition } = buildApp();
+      plugin = createPlugin(app);
+      await plugin.start({}, () => {});
+      await sendPosition(SF);
+
+      expect(publishedStationName(app)).toBe(nearestStation(SF).name);
+    });
+
+    it('publishes the configured default station', async () => {
+      // A real station near but not nearest to the SF position
+      const station = stationsNear({ ...SF, maxResults: 5 }).at(-1)!;
+      expect(station.id).not.toBe(nearestStation(SF).id);
+
+      const { app, sendPosition } = buildApp();
+      plugin = createPlugin(app);
+      await plugin.start({ defaultStation: station.id }, () => {});
+      await sendPosition(SF);
+
+      expect(publishedStationName(app)).toBe(station.name);
+    });
+
+    it('publishes the configured default station without a position', async () => {
+      const station = nearestStation(SF);
+      const { app, sendPosition } = buildApp();
+      plugin = createPlugin(app);
+      await plugin.start({ defaultStation: station.id }, () => {});
+      await sendPosition(null as unknown as Position);
+
+      expect(publishedStationName(app)).toBe(station.name);
+    });
+  });
+});


### PR DESCRIPTION
Lets users pick a **default tide station** in the plugin settings, instead of always using the station nearest the vessel.

- **Settings schema** — a `defaultStation` dropdown listing nearby stations (built from the vessel's last known position) plus a `Closest station (auto)` option. A saved station stays selectable even when it isn't currently nearby, so opening settings far from it (or before a position fix) can't clobber it on save.
- **Predictions & deltas** — the configured station drives the published `environment.tide.*` deltas and the `tides` resource. With a station set, predictions work even without a vessel position.
- **API** — the synthetic `stations/vessel/current` alias is **renamed to `stations/vessel/default`**, and bare `/extremes` and `/timeline` queries now resolve to the configured station too. When set to `auto` / unset (or the saved id is stale), they fall back to the vessel position so neaps uses the nearest station. Explicit `lat`/`lng` still win.

## Notes

- `vessel/current` → `vessel/default` is a **breaking rename** of the synthetic alias (also updated in the bundled webapp and README).
- `resolvePredictor` now catches `nearestStation` failures (logged, returns null) so a lookup error can't escape the update interval.

## Test plan

- `npm run test:node` — 44 passing (middleware redirect/injection matrix + plugin schema/delta coverage, incl. new default-station cases).
- `tsc` + `eslint` clean.
- Browser suite not run locally (needs `npx playwright install`); only a one-line constant in `app/App.tsx` changed.