### PR TITLE
Add station browser for switching tide stations

### DIFF
--- a/app/App.test.tsx
+++ b/app/App.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
 describe('App', () => {
@@ -30,5 +31,15 @@ describe('App', () => {
     // Verify no console errors or warnings
     expect(consoleErrorSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('opens the station browser from the menu button', async () => {
+    render(<App />);
+
+    const menu = await screen.findByRole('button', { name: /browse stations/i });
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    await userEvent.click(menu);
+    expect(await screen.findByRole('dialog')).toBeDefined();
   });
 });

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -2,8 +2,9 @@ import { NeapsProvider } from '@neaps/react'
 import './App.css'
 import { TideStation } from '@neaps/react';
 import { useUnitPreferences } from './hooks/useUnitPreferences'
+import { useStationId } from './hooks/useStationId'
+import { StationBrowser } from './StationBrowser'
 
-const VESSEL_STATION_ID = 'vessel/default';
 const { VITE_SIGNALK_URL = window.location.toString() } = import.meta.env;
 const API_BASE_URL = new URL("/signalk/v2/api", VITE_SIGNALK_URL).toString();
 
@@ -12,12 +13,16 @@ function App() {
   // resolved before mounting the provider — otherwise neaps fetches with the
   // wrong units and then refetches (the chart flips units) once they load.
   const { units, ready } = useUnitPreferences();
+  const [stationId, selectStation] = useStationId();
 
   if (!ready) return null;
 
   return (
     <NeapsProvider baseUrl={API_BASE_URL} units={units}>
-      <TideStation id={VESSEL_STATION_ID} className="overflow-y-auto p-2 sm:p-4 md:p-6 lg:p-8 xl:p-20" />
+      <div className="relative">
+        <StationBrowser stationId={stationId} onSelect={selectStation} />
+        <TideStation id={stationId} className="overflow-y-auto p-2 sm:p-4 md:p-6 lg:p-8 xl:p-20" />
+      </div>
     </NeapsProvider>
   )
 }

--- a/app/StationBrowser.tsx
+++ b/app/StationBrowser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   NearbyStations,
   StationSearch,
@@ -31,21 +31,16 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
   const dialog = useRef<HTMLDialogElement>(null);
   const [open, setOpen] = useState(false);
 
-  // Only mount the map (WebGL) on desktop, matching the `lg` breakpoint.
+  // Only mount the map (WebGL) on desktop. Evaluated when the modal opens —
+  // the decision only matters while it's open, so no resize listener is needed.
   const [desktop, setDesktop] = useState(false);
-  useEffect(() => {
-    const mq = window.matchMedia("(min-width: 1024px)");
-    const update = () => setDesktop(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, []);
 
   // The active station's coordinates, used to centre and highlight the map.
   // Resolves `vessel/default` to its real station server-side, same as TideStation.
   const { data: current } = useStation(stationId);
 
   const show = () => {
+    setDesktop(window.matchMedia("(min-width: 1024px)").matches);
     setOpen(true);
     dialog.current?.showModal();
   };

--- a/app/StationBrowser.tsx
+++ b/app/StationBrowser.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  NearbyStations,
+  StationSearch,
+  StationsMap,
+  useStation,
+  type StationSummary,
+} from "@neaps/react";
+import { VESSEL_STATION_ID } from "./hooks/useStationId";
+
+// No API key needed; OSM raster tiles are enough for browsing stations.
+const MAP_STYLE = {
+  version: 8 as const,
+  sources: {
+    osm: {
+      type: "raster" as const,
+      tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+      tileSize: 256,
+      attribution: "© OpenStreetMap contributors",
+    },
+  },
+  layers: [{ id: "osm", type: "raster" as const, source: "osm" }],
+};
+
+interface StationBrowserProps {
+  stationId: string;
+  onSelect: (id: string) => void;
+}
+
+export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
+  const dialog = useRef<HTMLDialogElement>(null);
+  const [open, setOpen] = useState(false);
+
+  // Only mount the map (WebGL) on desktop, matching the `lg` breakpoint.
+  const [desktop, setDesktop] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const update = () => setDesktop(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  // The active station's coordinates, used to centre and highlight the map.
+  // Resolves `vessel/default` to its real station server-side, same as TideStation.
+  const { data: current } = useStation(stationId);
+
+  const show = () => {
+    setOpen(true);
+    dialog.current?.showModal();
+  };
+
+  const select = (station: StationSummary) => {
+    onSelect(station.id);
+    dialog.current?.close();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={show}
+        aria-label="Browse stations"
+        className="absolute hidden min-[25rem]:block right-2 top-2 sm:right-4 sm:top-4 md:right-6 md:top-6 lg:right-8 lg:top-8 xl:right-20 xl:top-20 z-10 rounded-md border border-(--neaps-border) bg-(--neaps-bg-subtle) p-2 text-(--neaps-text) hover:bg-(--neaps-bg)"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
+
+      <dialog
+        ref={dialog}
+        onClose={() => setOpen(false)}
+        className="m-auto w-[min(92vw,900px)] max-h-[85vh] rounded-lg border border-(--neaps-border) bg-(--neaps-bg) p-0 text-(--neaps-text) backdrop:bg-black/50"
+      >
+        {open && (
+          <div className="flex max-h-[85vh] flex-col">
+            <div className="flex items-center justify-between border-b border-(--neaps-border) p-3">
+              <h2 className="text-base font-semibold">Stations</h2>
+              <button
+                type="button"
+                onClick={() => dialog.current?.close()}
+                aria-label="Close"
+                className="rounded-md p-1 text-(--neaps-text-muted) hover:text-(--neaps-text)"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="flex min-h-0 flex-col gap-4 p-3 lg:flex-row">
+              <div className="flex w-full flex-col gap-3 overflow-y-auto lg:w-80">
+                <StationSearch onSelect={select} />
+                <button
+                  type="button"
+                  onClick={() => select({ id: VESSEL_STATION_ID } as StationSummary)}
+                  className="rounded-md border border-(--neaps-border) px-3 py-2 text-left text-sm hover:bg-(--neaps-bg-subtle)"
+                >
+                  📍 Vessel position
+                </button>
+                <NearbyStations stationId={stationId} onStationSelect={select} />
+              </div>
+
+              {desktop && current && (
+                <div className="min-h-[400px] flex-1 overflow-hidden rounded-md border border-(--neaps-border)">
+                  <StationsMap
+                    mapStyle={MAP_STYLE}
+                    initialViewState={{
+                      longitude: current.longitude,
+                      latitude: current.latitude,
+                      zoom: 10,
+                    }}
+                    focusStation={current.id}
+                    onStationSelect={select}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </dialog>
+    </>
+  );
+}

--- a/app/hooks/useStationId.test.tsx
+++ b/app/hooks/useStationId.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useStationId, VESSEL_STATION_ID } from './useStationId';
+
+// Reset URL state between tests, preserving the test runner's path.
+afterEach(() => window.history.replaceState(null, '', window.location.pathname));
+
+describe('useStationId', () => {
+  it('defaults to the vessel station with no query param', () => {
+    const { result } = renderHook(() => useStationId());
+    expect(result.current[0]).toBe(VESSEL_STATION_ID);
+  });
+
+  it('reads the station from the query param', () => {
+    window.history.replaceState(null, '', '?station=noaa%2F9447130');
+    const { result } = renderHook(() => useStationId());
+    expect(result.current[0]).toBe('noaa/9447130');
+  });
+
+  it('selecting a station writes it to the query param', () => {
+    const { result } = renderHook(() => useStationId());
+    act(() => result.current[1]('noaa/9447130'));
+    expect(result.current[0]).toBe('noaa/9447130');
+    expect(new URLSearchParams(window.location.search).get('station')).toBe('noaa/9447130');
+  });
+
+  it('selecting the vessel station clears the query param', () => {
+    window.history.replaceState(null, '', '?station=noaa%2F9447130');
+    const { result } = renderHook(() => useStationId());
+    act(() => result.current[1](VESSEL_STATION_ID));
+    expect(result.current[0]).toBe(VESSEL_STATION_ID);
+    expect(window.location.search).toBe('');
+  });
+
+  it('preserves neaps’s hash when writing the station', () => {
+    window.history.replaceState(null, '', '#graph');
+    const { result } = renderHook(() => useStationId());
+    act(() => result.current[1]('noaa/9447130'));
+    expect(window.location.hash).toBe('#graph');
+  });
+});

--- a/app/hooks/useStationId.test.tsx
+++ b/app/hooks/useStationId.test.tsx
@@ -32,6 +32,20 @@ describe('useStationId', () => {
     expect(window.location.search).toBe('');
   });
 
+  it('treats an empty ?station= as the vessel station', () => {
+    window.history.replaceState(null, '', '?station=');
+    const { result } = renderHook(() => useStationId());
+    expect(result.current[0]).toBe(VESSEL_STATION_ID);
+  });
+
+  it('never writes a blank station id', () => {
+    window.history.replaceState(null, '', '?station=noaa%2F9447130');
+    const { result } = renderHook(() => useStationId());
+    act(() => result.current[1]('   '));
+    expect(result.current[0]).toBe(VESSEL_STATION_ID);
+    expect(window.location.search).toBe('');
+  });
+
   it('preserves neaps’s hash when writing the station', () => {
     window.history.replaceState(null, '', '#graph');
     const { result } = renderHook(() => useStationId());

--- a/app/hooks/useStationId.ts
+++ b/app/hooks/useStationId.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+
+// The SignalK plugin resolves this id to the station nearest the vessel.
+export const VESSEL_STATION_ID = "vessel/default";
+
+const readStation = () =>
+  new URLSearchParams(window.location.search).get("station") ?? VESSEL_STATION_ID;
+
+// Tracks the station being viewed in the `?station=` query param so the view is
+// shareable and back/forward navigable. neaps owns the URL hash (TideStation's
+// tabs), so keeping station in the query string sidesteps that namespace.
+export function useStationId(): [string, (id: string) => void] {
+  const [id, setId] = useState(readStation);
+
+  useEffect(() => {
+    const onPop = () => setId(readStation());
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  const select = useCallback((next: string) => {
+    const url = new URL(window.location.href); // preserves neaps's #tab hash
+    if (next === VESSEL_STATION_ID) url.searchParams.delete("station");
+    else url.searchParams.set("station", next);
+    // pushState (not replace) so the back button returns to the prior station.
+    window.history.pushState(window.history.state, "", url);
+    setId(next);
+  }, []);
+
+  return [id, select];
+}

--- a/app/hooks/useStationId.ts
+++ b/app/hooks/useStationId.ts
@@ -3,8 +3,9 @@ import { useCallback, useEffect, useState } from "react";
 // The SignalK plugin resolves this id to the station nearest the vessel.
 export const VESSEL_STATION_ID = "vessel/default";
 
+// `||` (not `??`) so an empty `?station=` falls back to the vessel station too.
 const readStation = () =>
-  new URLSearchParams(window.location.search).get("station") ?? VESSEL_STATION_ID;
+  new URLSearchParams(window.location.search).get("station") || VESSEL_STATION_ID;
 
 // Tracks the station being viewed in the `?station=` query param so the view is
 // shareable and back/forward navigable. neaps owns the URL hash (TideStation's
@@ -18,7 +19,8 @@ export function useStationId(): [string, (id: string) => void] {
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-  const select = useCallback((next: string) => {
+  const select = useCallback((raw: string) => {
+    const next = raw.trim() || VESSEL_STATION_ID; // never write a blank id
     const url = new URL(window.location.href); // preserves neaps's #tab hash
     if (next === VESSEL_STATION_ID) url.searchParams.delete("station");
     else url.searchParams.set("station", next);


### PR DESCRIPTION

<img width="1582" height="1035" alt="image" src="https://github.com/user-attachments/assets/25397ab9-1bba-4c0c-b73c-bf26d4d7b650" />

Lets users browse and switch tide stations instead of being pinned to the vessel's position. A menu button (top-right, over the tide view) opens a modal with `StationSearch`, a "Vessel position" reset, and a `NearbyStations` list; on desktop the modal also shows an interactive `StationsMap` centered on and highlighting the current station. Selecting a station anywhere closes the modal and switches the view.

The selected station lives in the `?station=` query param, so views are shareable and the browser back/forward buttons walk station history. neaps already owns the URL hash for `TideStation`'s tabs (it overwrites the whole fragment on every tab click), so keeping the station in the query string avoids that namespace entirely — the two coexist without interfering.

A couple of deliberate choices:

- **Map mounts on desktop only**, gated by a `matchMedia('(min-width: 1024px)')` check rather than CSS `hidden`, so phones never spin up a WebGL context or fetch tiles. The basemap is keyless OSM raster tiles — swap to a styled vector basemap later if we want nicer cartography.
- **The menu button hides below 25rem**, matching neaps's `COMPACT_MAX_WIDTH` widget threshold, so it never crowds the header in embedded/widget layouts. (It's a viewport query vs. neaps's container query, but they line up here since the tide view fills the viewport.)
- Modal contents render only while open, so a closed dialog fires no station queries.

Tests: `useStationId` query-param behavior (default, read, write, clear, hash-preservation) plus an App test that the menu opens the dialog. Full suite green (44 node + 12 browser).

Fixes #15