### PR TITLE
Make vessel-position injection Express 5 compatible

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -86,8 +86,19 @@ export function withVesselPosition(
 
       const pos = getPosition();
       if (pos) {
-        req.query.latitude = String(pos.latitude);
-        req.query.longitude = String(pos.longitude);
+        // Express 5 makes `req.query` a read-only getter, so assigning to its
+        // properties is silently lost. Shadow it with an own data property,
+        // which behaves identically on Express 4 and 5.
+        Object.defineProperty(req, "query", {
+          value: {
+            ...req.query,
+            latitude: String(pos.latitude),
+            longitude: String(pos.longitude),
+          },
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
       }
     }
 


### PR DESCRIPTION
## Problem

`withVesselPosition` injects the vessel's position into bare `/extremes` and `/timeline` requests by assigning to `req.query.latitude` and `req.query.longitude`. Express 5 makes `req.query` a read-only getter, so those assignments are silently dropped. The position never reaches the Neaps router, and the location-based queries stop resolving to the nearest station.

This only shows up under Express 5. In production the plugin runs inside signalk-server (Express 4), where the write still works, so nothing is broken today. But the plugin's own tests run on Express 5 and 4 of them fail. It's fragile regardless: it works only because the host happens to own the request with Express 4.

## Fix

Shadow `req.query` with an own data property via `Object.defineProperty` instead of mutating it. That behaves the same on Express 4 and 5, so position injection works no matter which Express version owns the request.

## Testing

- Express 5: full node suite passes (44/44); middleware 28/28 (was 24/28)
- Express 4: middleware 28/28, no regression

This just makes the code Express 5 ready. The dependency bump itself lands separately via Dependabot (#54).
