### PR TITLE
Bump @neaps/react to 0.1.1 for responsive TideStation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@neaps/api": "^0.5.1",
-    "@neaps/react": "^0.1.0",
+    "@neaps/react": "^0.1.1",
     "@signalk/server-api": "^2.28.0",
     "express": "^4.0",
     "neaps": "^0.7.0",


### PR DESCRIPTION
Bumps `@neaps/react` from `^0.1.0` to `^0.1.1` to pull in the responsive `<TideStation>` layout fix ([neaps#286](https://github.com/openwatersio/neaps/pull/286)).

With 0.1.1, `<TideStation>` keeps the stacked continuous-scroll view in narrow, content-sized containers (phones in portrait) and only switches to the tabbed layout when an ancestor constrains the height below 500px. The tab bar collapses to a dropdown based on height instead of width.

Patch bump, no API changes. Build and node tests pass locally (44/44).
