### PR TITLE
Upgrade to Express 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@neaps/api": "^0.5.1",
+    "@neaps/api": "^0.6.0",
     "@neaps/react": "^0.1.1",
     "@signalk/server-api": "^2.28.0",
-    "express": "^4.0",
+    "express": "^5.2.1",
     "neaps": "^0.7.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -48,7 +48,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/express": "^4.0",
+    "@types/express": "^5.0.6",
     "@types/node": "^26.0.1",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -86,8 +86,19 @@ export function withVesselPosition(
 
       const pos = getPosition();
       if (pos) {
-        req.query.latitude = String(pos.latitude);
-        req.query.longitude = String(pos.longitude);
+        // Express 5 makes `req.query` a read-only getter, so assigning to its
+        // properties is silently lost. Shadow it with an own data property,
+        // which behaves identically on Express 4 and 5.
+        Object.defineProperty(req, "query", {
+          value: {
+            ...req.query,
+            latitude: String(pos.latitude),
+            longitude: String(pos.longitude),
+          },
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
       }
     }
 


### PR DESCRIPTION
Adopts Express 5 in the plugin, verified running live against signalk-server.

## Changes
- Bump `express` to `^5.2.1` and `@types/express` to `^5.0.6`
- Bump `@neaps/api` to `^0.6.0` (its Express 5 release), which aligns the router types so the build type-checks
- Make vessel-position injection Express 5 compatible: `withVesselPosition` now shadows `req.query` with an own data property instead of assigning to it. Express 5 made `req.query` a read-only getter, so the old assignment was silently dropped, which broke bare `/extremes` and `/timeline` position resolution.

## Testing
- Build (tsc + vite) passes; 44/44 node tests pass on Express 5, and still pass on Express 4 (no regression).
- Verified live: installed in a running signalk-server (Express 4 host) with @neaps/api 0.6.0's Express 5 router mounted. Station lookups and predictions return 200, vessel/default position redirects return 303, no errors.

Supersedes #54 (Dependabot express bump) and folds in #91 (the req.query fix).
