### PR TITLE
Upgrade to TypeScript 6 and ESLint 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
+    "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.1.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
@@ -57,7 +57,7 @@
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/ui": "^4.0.18",
-    "eslint": "^10.4.1",
+    "eslint": "^10.6.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
@@ -69,8 +69,8 @@
     "signalk-server": "^2.13.5",
     "supertest": "^7.2.2",
     "tailwindcss": "^4.1.3",
-    "typescript": "^5.8.2",
-    "typescript-eslint": "^8.24.1",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.63.0",
     "vite": "^8.0.16",
     "vitest": "^4.0.18"
   },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
     "noEmit": true,
-    "rootDir": ".",
+    "rootDir": "."
   },
   "include": ["test"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
     "noEmit": true,
+    "rootDir": ".",
   },
   "include": ["test"]
 }


### PR DESCRIPTION
Upgrades the dev tooling to TypeScript 6 and ESLint 10.

## Changes
- `typescript` 5.8 → ^6.0.3
- `@eslint/js` 9 → ^10.0.1, and `eslint` → ^10.6.0 (repo was already on 10)
- `typescript-eslint` 8.24 → ^8.63.0, so it supports TS 6 and ESLint 10
- `tsconfig.node.json` / `tsconfig.test.json`: set `rootDir` explicitly. TS 6 now requires it when a project emits into an `outDir` (TS5011). The test config extends the node config, so it gets `rootDir: "."` to cover `test/` and the `src/` it imports.

## Verified
- `eslint .`: clean
- `npm run build` (tsc -b + vite build): passes
- node tests: 44/44 (browser tests run in CI)

Note: ESLint 10 requires Node >=20.19 / 22.13 / 24.

Supersedes #71 (typescript), #44 (@eslint/js).
