### PR TITLE
Pin ajv to v8 to fix express-openapi-validator resolution (#95)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@neaps/api": "^0.6.0",
     "@neaps/react": "^0.1.1",
     "@signalk/server-api": "^2.28.0",
+    "ajv": "^8.17.1",
     "express": "^5.2.1",
     "neaps": "^0.7.0",
     "react": "^19.1.0",


### PR DESCRIPTION
Prototype fix for #95 — signalk-tides 2.1.0 failing to start with `Cannot find module 'ajv/dist/core'`.

## Cause
The plugin's request validation (`express-openapi-validator`, pulled in by `@neaps/api`) needs **ajv 8** — `ajv-draft-04` does `require('ajv/dist/core')`, a path that only exists in ajv 8. signalk-server ships **ajv 6** at the top of `~/.signalk/node_modules`. When npm hoists `ajv-draft-04` up next to signalk-server's ajv 6, it resolves the wrong ajv and the plugin crashes on load. It's install-dependent (npm hoisting), so it hits some users and not others.

## This change
Declares `ajv@^8` as a direct dependency. The plugin doesn't import ajv itself — this just pins the version the transitive validator chain resolves, so ajv 8 is present in the plugin's own subtree.

## Caveat (why this is a draft)
This is the lightweight fix. It doesn't guarantee resolution in every hoisting layout: if `ajv-draft-04` still lands hoisted to the very top next to signalk-server's ajv 6, only bundling the plugin's server (so its deps are self-contained) fully guarantees it. Draft first, to see whether this alone clears the reported case.

Verified: installs clean, build passes, 44 node tests pass.
