### PR TITLE
Bundle the plugin server with esbuild (durable fix for #95)

### DIFF
--- a/esbuild.server.mjs
+++ b/esbuild.server.mjs
@@ -1,0 +1,36 @@
+import * as esbuild from "esbuild";
+import { rm } from "node:fs/promises";
+
+// tsc -b (run first for type-checking) emits unbundled files into dist/. Clear
+// them so the published dist/ is just the self-contained bundle.
+await rm("dist", { recursive: true, force: true });
+
+// Bundle the plugin's server entry (src/index.ts) into a single self-contained
+// dist/index.js. Baking express-openapi-validator + ajv 8 into the bundle means
+// they resolve against the versions we ship, not whatever signalk-server has
+// hoisted into ~/.signalk/node_modules. This is the durable fix for #95, where
+// npm sometimes leaves ajv-draft-04 hoisted next to signalk-server's ajv 6
+// (which has no dist/core), crashing the plugin on load.
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  outfile: "dist/index.js",
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node20",
+  sourcemap: false,
+  // What must be bundled to fix #95 is the @neaps/api -> express-openapi-validator
+  // -> ajv/ajv-draft-04 chain, so ajv 8 resolves against our copy instead of
+  // signalk-server's hoisted ajv 6. Everything else is safe to leave external:
+  //   - @signalk/server-api: types only (erased), provided by the host.
+  //   - neaps: the offline tide engine we import directly. Large station data,
+  //     no ajv dependency, so bundling it just bloats dist for no benefit.
+  //   - Node built-ins: external automatically on platform: "node".
+  external: ["@signalk/server-api", "neaps"],
+  // Some bundled CJS deps (express, ajv) do dynamic require() calls that can't
+  // be resolved statically. Provide a require() in the ESM output so they work.
+  banner: {
+    js: "import { createRequire as __createRequire } from 'module';\nconst require = __createRequire(import.meta.url);",
+  },
+  logLevel: "info",
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "scripts": {
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && npm run build:server && vite build",
+    "build:server": "node esbuild.server.mjs",
     "dev": "vite",
     "lint": "eslint .",
     "prepack": "npm run build",
@@ -34,7 +35,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@neaps/api": "^0.6.0",
     "@neaps/react": "^0.1.1",
     "@signalk/server-api": "^2.28.0",
     "express": "^5.2.1",
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@neaps/api": "^0.6.0",
     "@tailwindcss/vite": "^4.1.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
@@ -57,6 +58,7 @@
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/ui": "^4.0.18",
+    "esbuild": "^0.28.0",
     "eslint": "^10.4.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",


### PR DESCRIPTION
Durable fix for #95, where the plugin crashes on some installs with `Cannot find module 'ajv/dist/core'`.

## The problem

`@neaps/api` pulls in `express-openapi-validator`, which needs ajv 8. signalk-server ships ajv 6 at the top of `~/.signalk/node_modules`. Normally npm nests our ajv 8 next to the validator. But in some installs (usually after the plugin is updated in place) it leaves `ajv-draft-04` hoisted to the top, where it resolves signalk-server's ajv 6, which has no `dist/core`, and crashes on load.

A plugin can't reliably control how the host hoists the shared tree. Plugin-level `overrides` are ignored by the root `~/.signalk` install, and adding an ajv dep doesn't dislodge a copy that's already hoisted (see #97).

## The fix

Bundle `src/index.ts` into a self-contained `dist/index.js` with esbuild. The `@neaps/api` → `express-openapi-validator` → ajv chain is baked in and resolves against our copy, no matter how the host lays out its `node_modules`. `neaps` (the offline tide engine, which has no ajv dependency) and node built-ins stay external.

The bundle inlines `@neaps/api` completely, so it moves to `devDependencies`. It's a build input now, not a runtime dep.

## Verification

- `npm run build` (tsc type-check + esbuild + vite) passes. All 44 node tests pass.
- Bundled a probe that calls `createRoutes()`, which triggers the express-openapi-validator schema compilation through ajv, and ran it in a hostile environment: ajv 6 hoisted at the top, `ajv/dist/core` unresolvable, `@neaps/api` not installed at all. It compiled the schema and returned a working router. That's the exact #95 crash path, and it no longer fires.

## The tradeoff

`dist/index.js` comes out around 37MB, because `@neaps/api` bakes in offline tide-station data. Moving it to `devDependencies` means we don't ship that data twice, so net install size is about what it was before. The cost is a single large file that gets parsed at startup.

There's a lighter fix at the root: have `@neaps/api` bundle its own `express-openapi-validator` + ajv, the way it already bundles the tide data. That's ~0.5MB and it fixes every downstream consumer, instead of making each plugin carry a 37MB bundle. Happy to take that upstream instead if you'd rather.

Draft — not for merge until you've picked between this and the upstream option.

Closes #95 (if we go with this approach).
