### PR TITLE
Fix station selector on mobile

### DIFF
--- a/app/StationBrowser.tsx
+++ b/app/StationBrowser.tsx
@@ -74,7 +74,7 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
         onClick={(e) => {
           // Light-dismiss: a native modal dialog ignores backdrop taps, so close
           // when the click lands on the dialog element itself rather than content.
-          if (e.target === dialog.current) dialog.current?.close();
+          if (e.target === e.currentTarget) e.currentTarget.close();
         }}
         className="m-auto w-[min(92vw,900px)] max-h-[85vh] rounded-lg border border-(--neaps-border) bg-(--neaps-bg) p-0 text-(--neaps-text) backdrop:bg-black/50"
       >

--- a/app/StationBrowser.tsx
+++ b/app/StationBrowser.tsx
@@ -31,9 +31,11 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
   const dialog = useRef<HTMLDialogElement>(null);
   const [open, setOpen] = useState(false);
 
-  // Only mount the map (WebGL) on desktop. Evaluated when the modal opens —
-  // the decision only matters while it's open, so no resize listener is needed.
+  // Desktop shows the list and map side by side; mobile toggles between them.
+  // Evaluated when the modal opens — the decision only matters while it's open,
+  // so no resize listener is needed.
   const [desktop, setDesktop] = useState(false);
+  const [view, setView] = useState<"list" | "map">("list");
 
   // The active station's coordinates, used to centre and highlight the map.
   // Resolves `vessel/default` to its real station server-side, same as TideStation.
@@ -41,6 +43,7 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
 
   const show = () => {
     setDesktop(window.matchMedia("(min-width: 1024px)").matches);
+    setView("list");
     setOpen(true);
     dialog.current?.showModal();
   };
@@ -56,7 +59,7 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
         type="button"
         onClick={show}
         aria-label="Browse stations"
-        className="absolute hidden min-[25rem]:block right-2 top-2 sm:right-4 sm:top-4 md:right-6 md:top-6 lg:right-8 lg:top-8 xl:right-20 xl:top-20 z-10 rounded-md border border-(--neaps-border) bg-(--neaps-bg-subtle) p-2 text-(--neaps-text) hover:bg-(--neaps-bg)"
+        className="absolute hidden min-[20rem]:block right-2 top-2 sm:right-4 sm:top-4 md:right-6 md:top-6 lg:right-8 lg:top-8 xl:right-20 xl:top-20 z-10 rounded-md border border-(--neaps-border) bg-(--neaps-bg-subtle) p-2 text-(--neaps-text) hover:bg-(--neaps-bg)"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
           <line x1="3" y1="6" x2="21" y2="6" />
@@ -68,24 +71,58 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
       <dialog
         ref={dialog}
         onClose={() => setOpen(false)}
+        onClick={(e) => {
+          // Light-dismiss: a native modal dialog ignores backdrop taps, so close
+          // when the click lands on the dialog element itself rather than content.
+          if (e.target === dialog.current) dialog.current?.close();
+        }}
         className="m-auto w-[min(92vw,900px)] max-h-[85vh] rounded-lg border border-(--neaps-border) bg-(--neaps-bg) p-0 text-(--neaps-text) backdrop:bg-black/50"
       >
         {open && (
           <div className="flex max-h-[85vh] flex-col">
             <div className="flex items-center justify-between border-b border-(--neaps-border) p-3">
-              <h2 className="text-base font-semibold">Stations</h2>
               <button
                 type="button"
                 onClick={() => dialog.current?.close()}
                 aria-label="Close"
-                className="rounded-md p-1 text-(--neaps-text-muted) hover:text-(--neaps-text)"
+                className="grid size-11 place-items-center rounded-md text-(--neaps-text-muted) hover:text-(--neaps-text)"
               >
                 ✕
+              </button>
+              <h2 className="text-base font-semibold">Stations</h2>
+              {/* Mobile-only list/map toggle; invisible on desktop (both are shown)
+                  but keeps its box so the title stays centred. */}
+              <button
+                type="button"
+                onClick={() => setView(view === "map" ? "list" : "map")}
+                aria-label={view === "map" ? "Show list" : "Show map"}
+                className="grid size-11 place-items-center rounded-md text-(--neaps-text-muted) hover:text-(--neaps-text) lg:invisible"
+              >
+                {view === "map" ? (
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <line x1="8" y1="6" x2="21" y2="6" />
+                    <line x1="8" y1="12" x2="21" y2="12" />
+                    <line x1="8" y1="18" x2="21" y2="18" />
+                    <line x1="3" y1="6" x2="3.01" y2="6" />
+                    <line x1="3" y1="12" x2="3.01" y2="12" />
+                    <line x1="3" y1="18" x2="3.01" y2="18" />
+                  </svg>
+                ) : (
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21 3 6" />
+                    <line x1="9" y1="3" x2="9" y2="18" />
+                    <line x1="15" y1="6" x2="15" y2="21" />
+                  </svg>
+                )}
               </button>
             </div>
 
             <div className="flex min-h-0 flex-col gap-4 p-3 lg:flex-row">
-              <div className="flex w-full flex-col gap-3 overflow-y-auto lg:w-80">
+              <div
+                className={`w-full flex-col gap-3 overflow-y-auto lg:flex lg:w-80 ${
+                  view === "map" ? "hidden" : "flex"
+                }`}
+              >
                 <StationSearch onSelect={select} />
                 <button
                   type="button"
@@ -97,8 +134,10 @@ export function StationBrowser({ stationId, onSelect }: StationBrowserProps) {
                 <NearbyStations stationId={stationId} onStationSelect={select} />
               </div>
 
-              {desktop && current && (
-                <div className="min-h-[400px] flex-1 overflow-hidden rounded-md border border-(--neaps-border)">
+              {(desktop || view === "map") && current && (
+                // Mobile needs a definite height (h-[60vh]) so neaps's height:100%
+                // map resolves; desktop gets its height from the flex-row stretch.
+                <div className="h-[60vh] overflow-hidden rounded-md border border-(--neaps-border) lg:h-auto lg:min-h-100 lg:flex-1">
                   <StationsMap
                     mapStyle={MAP_STYLE}
                     initialViewState={{


### PR DESCRIPTION
Three fixes to the station browser based on iPhone feedback: you couldn't switch stations without rotating the phone, the ✕ didn't reliably dismiss the dialog, and the stations map only rendered on desktop. All changes are in `app/StationBrowser.tsx`.

**Browse button now shows in portrait.** It was hidden below 400px (`min-[25rem]`) — just above iPhone-portrait width — so switching stations meant turning the phone sideways. Lowered to 320px (`min-[20rem]`), which still hides it in a sub-320px embedded widget.

**Dialog is reliably dismissable on touch.** The ✕ was a 20px glyph; it's now a 44×44 tap target. Also added backdrop-tap-to-close, since a native modal `<dialog>` ignores backdrop clicks by default and tapping outside is the instinctive mobile dismiss. Esc already worked.

**Stations map works on mobile.** The header now carries a map/list icon toggle — ✕ moves to the left, the title centres, and the right-hand icon flips between a map icon (list view) and a list icon (map view). The map mounts only when shown, so WebGL still doesn't spin up on the list view. Desktop keeps the side-by-side list+map layout unchanged; the toggle is invisible there but holds its box so the title stays centred.

Verified in-browser at iPhone-portrait (390px) and desktop widths: button visibility, ✕ and backdrop dismiss, and the map rendering with station pins. `npm run lint` clean, 58/58 tests pass.

One known edge left as-is (matches existing behaviour): rotating the phone while the dialog is open doesn't re-evaluate the desktop/mobile layout — it's decided when the dialog opens.