### PR TITLE
feat(widgets): add Neaps-powered tide-graph widget for plotter-extension hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 package-lock.json
 dist
 .env*
+
+# Vitest browser-mode artifacts (failure screenshots / attachments)
+__screenshots__
+.vitest-attachments

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,9 @@
 /*config.{mjs,js,ts,mts}
 /test
 /index.html
+
+# Widget source ships only as the built widgets/dist assets.
+/widgets/web
+/widgets/test
+/widgets/SPEC.md
+/widgets/vite.config.mts

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "scripts": {
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && vite build --config widgets/vite.config.mts",
     "dev": "vite",
     "lint": "oxlint",
     "prepack": "npm run build",
@@ -40,7 +40,8 @@
     "express": "^5.2.1",
     "neaps": "^0.7.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "signalk-plotterext-bus": "^0.10.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { findStation, nearestStation, stationsNear } from "neaps";
 import { tideStateAt, timeToNextExtreme } from "./calculations.js";
 import FileCache from "./cache.js";
 import { withVesselPosition } from "./middleware.js";
+import { registerTideGraphWidget } from "./plotterext.js";
 
 type Predictor = ReturnType<typeof findStation>;
 type Forecast = ReturnType<Predictor["getExtremesPrediction"]>;
@@ -117,6 +118,9 @@ export default function (app: ServerAPI): Plugin {
   async function start(options?: object) {
     app.debug("Starting tides");
     config = (options ?? {}) as Config;
+
+    // Contribute the 2x1 tide-graph widget to Plotter Extensions hosts.
+    registerTideGraphWidget(app);
 
     // Keep the forecast and the predictor that produced it together, so the
     // extremes and the current height are always read from the same station.

--- a/src/plotterext.ts
+++ b/src/plotterext.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 Brandon Keepers <brandon@opensoul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Plotter Extensions provider: contributes a single 2x1 "Tide Graph" widget to
+// chart-plotter web apps (Freeboard-SK and any other Plotter Extensions host).
+// The widget is a sandboxed iframe served from a public static route; it reuses
+// the plugin's own Neaps API for the full multi-day harmonic curve. This is a
+// read-only provider whose one resource is the extension manifest — no user
+// data, purely additive, and it touches none of the existing deltas, the Neaps
+// API, or the `tides` resource.
+//
+// Registration lives here (compiled into the plugin's `dist/`) rather than
+// under `widgets/` because the plugin's flat `dist/` output layout depends on
+// `src/` being the sole TypeScript rootDir; the browser widget source and its
+// build live under `widgets/`.
+
+import express from "express";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ServerAPI } from "@signalk/server-api";
+
+const require = createRequire(import.meta.url);
+
+// Manifest key = package name; the Signal K plugin id is `tides`.
+export const PACKAGE_NAME = "signalk-tides";
+const ASSET_BASE = `/plotterext/${PACKAGE_NAME}`;
+const CONFIG_PANEL_ID = "graph-config";
+
+// Built widget iframe assets. From dist/plotterext.js this resolves to the
+// package's widgets/dist directory (built by `vite --config widgets/vite.config.mts`).
+const WIDGET_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "widgets",
+  "dist",
+);
+
+function packageVersion(): string | undefined {
+  try {
+    return (require("../package.json") as { version?: string }).version;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The extension manifest advertised to hosts. Pure and side-effect free so it
+ * can be unit-tested directly. `requires: ["widgets"]` only — the widget's data
+ * is fetched over same-origin REST (the Neaps API), so it is offered even on
+ * hosts that do not relay the Signal K stream. `units` and `panels.iframe` are
+ * optional refinements (display-unit preference and the config panel).
+ */
+export function buildManifest() {
+  return {
+    name: "Tides",
+    description:
+      "Tide-curve widget for the vessel's position, powered by Neaps.",
+    version: packageVersion(),
+    apiVersion: "1",
+    requires: ["widgets"],
+    // `map` lets the widget optionally follow the charted area instead of the
+    // vessel (map.getView); hosts without it just show vessel tides.
+    optional: ["units", "panels.iframe", "map"],
+    widgets: [
+      {
+        id: "graph",
+        title: "Tide Cycle (Advanced)",
+        type: "iframe",
+        url: `${ASSET_BASE}/graph.html`,
+        size: "2x1",
+        configPanel: CONFIG_PANEL_ID,
+        lifecycle: "whileEnabled",
+      },
+    ],
+    panels: [
+      {
+        id: CONFIG_PANEL_ID,
+        title: "Tide Cycle Settings",
+        type: "iframe",
+        url: `${ASSET_BASE}/config.html`,
+        lifecycle: "onOpen",
+      },
+    ],
+  };
+}
+
+// Express cannot unmount middleware, so guard the static route against a
+// second start() (e.g. a disable/enable cycle) mounting it twice.
+let assetsMounted = false;
+
+/**
+ * Serve the widget assets on a public, non-admin route and register the
+ * read-only `plotterExtensions` provider. Call once from the plugin's start().
+ */
+export function registerTideGraphWidget(app: ServerAPI): void {
+  if (!assetsMounted) {
+    // @ts-expect-error: app is an Express app at runtime
+    if (typeof app.use === "function") {
+      // @ts-expect-error: app is an Express app at runtime
+      app.use(ASSET_BASE, express.static(WIDGET_DIR));
+      assetsMounted = true;
+      app.debug(`Serving tide-graph widget assets at ${ASSET_BASE}`);
+    }
+  }
+
+  app.registerResourceProvider({
+    type: "plotterExtensions",
+    methods: {
+      async listResources() {
+        return { [PACKAGE_NAME]: buildManifest() } as unknown as Record<
+          string,
+          unknown
+        >;
+      },
+      async getResource(id: string) {
+        if (id !== PACKAGE_NAME) {
+          throw new Error(`No such plotterExtensions resource: ${id}`);
+        }
+        return buildManifest() as unknown as object;
+      },
+      setResource(): never {
+        throw new Error("signalk-tides plotterExtensions is read-only");
+      },
+      deleteResource(): never {
+        throw new Error("signalk-tides plotterExtensions is read-only");
+      },
+    },
+  });
+}

--- a/test/plotterext.test.ts
+++ b/test/plotterext.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildManifest,
+  registerTideGraphWidget,
+  PACKAGE_NAME,
+} from "../src/plotterext.js";
+
+describe("buildManifest", () => {
+  const manifest = buildManifest();
+
+  it("advertises API version 1 and requires the widgets capability", () => {
+    expect(manifest.apiVersion).toBe("1");
+    expect(manifest.requires).toContain("widgets");
+    // Data is same-origin REST, so no stream requirement.
+    expect(manifest.requires).not.toContain("signalk.stream");
+    expect(manifest.optional).toEqual(
+      expect.arrayContaining(["units", "panels.iframe", "map"]),
+    );
+  });
+
+  it("declares exactly one 2x1 graph widget served from the public route", () => {
+    expect(manifest.widgets).toHaveLength(1);
+    const [widget] = manifest.widgets;
+    expect(widget.id).toBe("graph");
+    expect(widget.title).toBe("Tide Cycle (Advanced)");
+    expect(widget.type).toBe("iframe");
+    expect(widget.size).toBe("2x1");
+    expect(widget.size).toMatch(/^[12]x[12]$/);
+    expect(widget.url).toBe("/plotterext/signalk-tides/graph.html");
+    expect(widget.configPanel).toBe("graph-config");
+  });
+
+  it("declares the graph-config panel", () => {
+    expect(manifest.panels).toHaveLength(1);
+    const [panel] = manifest.panels;
+    expect(panel.id).toBe("graph-config");
+    expect(panel.type).toBe("iframe");
+    expect(panel.url).toBe("/plotterext/signalk-tides/config.html");
+  });
+
+  it("includes the package version", () => {
+    expect(manifest.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("registerTideGraphWidget", () => {
+  function fakeApp() {
+    return {
+      use: vi.fn(),
+      registerResourceProvider: vi.fn(),
+      debug: vi.fn(),
+    };
+  }
+
+  it("serves assets on a public, non-admin route", () => {
+    const app = fakeApp();
+    registerTideGraphWidget(app as never);
+    expect(app.use).toHaveBeenCalledWith(
+      "/plotterext/signalk-tides",
+      expect.any(Function),
+    );
+    // The public route is deliberately not under /plugins/*.
+    const [route] = app.use.mock.calls[0];
+    expect(route).not.toMatch(/^\/plugins\b/);
+  });
+
+  it("registers a read-only plotterExtensions provider keyed by the package name", async () => {
+    const app = fakeApp();
+    registerTideGraphWidget(app as never);
+
+    expect(app.registerResourceProvider).toHaveBeenCalledTimes(1);
+    const { type, methods } = app.registerResourceProvider.mock.calls[0][0];
+    expect(type).toBe("plotterExtensions");
+
+    const list = await methods.listResources();
+    expect(Object.keys(list)).toEqual([PACKAGE_NAME]);
+
+    const resource = await methods.getResource(PACKAGE_NAME);
+    expect(resource).toMatchObject({ apiVersion: "1", name: "Tides" });
+
+    await expect(methods.getResource("something-else")).rejects.toThrow();
+    expect(() => methods.setResource()).toThrow(/read-only/);
+    expect(() => methods.deleteResource()).toThrow(/read-only/);
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["app"]
+  "include": ["app", "widgets/web", "widgets/test"]
 }

--- a/vitest.config.browser.ts
+++ b/vitest.config.browser.ts
@@ -22,6 +22,6 @@ export default defineConfig({
       // (it switches to a tabbed layout in narrow containers)
       instances: [{ browser: 'chromium', viewport: { width: 1280, height: 800 } }],
     },
-    include: ["app/**/*.test.{ts,tsx}"],
+    include: ["app/**/*.test.{ts,tsx}", "widgets/test/**/*.test.tsx"],
   },
 });

--- a/widgets/SPEC.md
+++ b/widgets/SPEC.md
@@ -1,0 +1,324 @@
+# SPEC — Tide‑graph widget for `signalk-tides` (`widgets/` enhancement)
+
+> **Scope:** a **single** full‑fidelity **2×1 tide‑graph widget** ("Tide Cycle
+> (Advanced)") contributed to the `signalk-tides` plugin, powered by its own
+> **Neaps** data. Not a whole‑project spec and not a pack — exactly one premium
+> widget that shows how a data plugin can publish an integrated chart‑plotter
+> widget alongside its core service, via the host‑agnostic **Plotter Extensions
+> API**.
+>
+> A separate, standalone pack (`signalk-basic-tide-widgets`) covers the
+> lightweight, deltas‑only widgets (a 1×1 level and a 2×1 *estimated* cycle).
+> **This** widget is the high‑fidelity counterpart and lives **with**
+> `signalk-tides` because only it has the Neaps harmonic data.
+
+---
+
+## 1. Objective & intent
+
+Add one optional, full‑fidelity **tide‑graph widget** to `signalk-tides` that
+renders the same multi‑day harmonic curve as its webapp — reusing `@neaps/react`
+— so any Plotter Extensions host (Freeboard‑SK and others) can place it directly
+on the chart. The plugin's existing behaviour is **unchanged** (webapp, deltas,
+Neaps API, `tides` resource all untouched); the feature is purely additive.
+
+**Why this PR exists.** It is a *demonstration* of the Plotter Extensions API and
+a *spotlight* on excellent existing work, not a takeover. It should be
+deferential and minimal, **credit Neaps / openwaters.io**, and read as a template
+other plugin authors can copy.
+
+### Upstream / fork context
+
+`joelkoz/signalk-tides` is a fork of **`openwatersio/signalk-tides`** (Brandon
+Keepers / openwaters.io, the Neaps authors). The PR targets `openwatersio:main`.
+Standard Signal K contribution rules apply: Conventional‑Commits title, one
+logical change, **no version bump**, minimal footprint.
+
+### Reference material
+
+- **API contract:** the Plotter Extensions API (`docs/api/plotter-extensions-api.md`
+  in `SignalK/freeboard-sk`).
+- **Wire contract:** the `signalk-plotterext-bus` npm package (JSON‑RPC over
+  `postMessage`); the widget uses its `/extension` entry.
+- **Registration / packaging pattern:** a read‑only `plotterExtensions` resource
+  provider plus a self‑served public static route (mirrors
+  `signalk-instrument-widgets` / `signalk-basic-tide-widgets`).
+
+---
+
+## 2. The widget — `graph` (2×1) — "Tide Cycle (Advanced)"
+
+| id | title | size | extension (manifest name) |
+|----|-------|------|---------------------------|
+| `graph` | **Tide Cycle (Advanced)** | `2x1` | **Tides** |
+
+A host's picker reads `Tides › Tide Cycle (Advanced)` — deliberately paired
+against `Basic Tides › Tide Cycle (Basic)` from the standalone pack, so the
+premium (Neaps‑powered) one is easy to tell apart.
+
+**Behaviour**
+
+- Renders the multi‑day tide **curve** with high/low markers, the mean‑low
+  reference line, daylight shading and a live "now" indicator — reusing
+  `@neaps/react`'s **static** graph pieces (see §3).
+- **Static, not interactive.** A widget is a guest on the chart, not an app:
+  **no scrolling, no "Now" button, no tooltip/selection.** Pointer events pass
+  through (`pointer-events: none` on the chart) so the host still sees the
+  press‑and‑hold that opens the config panel.
+- Honours the host's preferred depth unit (`units.get`, then the server's active
+  unit preset, then the locale default).
+- Shows the **tide station name** clipped in the top‑left corner (so in
+  chart‑follow mode the user can see which station the charted area resolved to).
+- Compact and legible at 2×1; translucent‑dark; transparent background;
+  responsive. Degrades quietly before a position/forecast exists (placeholder),
+  never an error stack.
+- Provides a **configuration panel** (`graph-config`, §3b) opened on long‑press.
+
+**Out of scope (this PR)**
+
+- The 1×1 text widget (that lives in `signalk-basic-tide-widgets`).
+- Background runtimes, buttons, routes/filters.
+- Any change to existing deltas, the Neaps API, the `tides` resource, or the webapp.
+
+---
+
+## 3. Architecture & data flow
+
+The widget is a sandboxed **iframe** the host loads from
+`/plotterext/signalk-tides/…` (same origin as the SK server). It connects to the
+host over the bus via `signalk-plotterext-bus/extension`.
+
+- **Host bus** is used for: handshake/lifecycle, display‑unit preference
+  (`units.get`), per‑instance config (`state.get`/`state.set` — the graph window
+  and location mode), the long‑press → `ui.openConfigPanel` gesture, and — in
+  chart‑follow mode — the chart view (`map.getView`).
+- **Tide data** comes from the plugin's own public **Neaps API** over same‑origin
+  REST, via `@neaps/react`'s `NeapsProvider` pointed at `/signalk/v2/api`. This
+  reuses the existing, tested data path and gives multi‑day fidelity the deltas
+  can't.
+
+**Static graph — composed, not the interactive wrapper.** `@neaps/react`'s
+high‑level `<TideGraph>` is a scrollable, infinite‑loading, tooltip‑driven chart
+built for the webapp. A widget must be static, so instead we compose the
+lower‑level **static** exports the library already provides — the pure
+`<TideGraphChart>` SVG plus the `useTimeline` / `useExtremes` / `useCurrentLevel`
+data hooks. No `@neaps/react` code is copied; only its public API is used at a
+lower level. The chart's x‑domain is the fetched timeline's extent, so the chosen
+window (§3b) is just the span of the timeline we request.
+
+**Location — vessel or chart centre (§3c).** By default the graph shows tides for
+the vessel's own station (`vessel/default`). Optionally it follows the charted
+area, querying Neaps by the chart‑centre lat/lon.
+
+**Capabilities.** `requires: ["widgets"]`; `optional: ["units", "panels.iframe",
+"map"]`. No `signalk.stream` — data is REST, so the widget is offered even on
+hosts that don't relay the stream. `map` is optional: without it the widget just
+shows vessel tides.
+
+**Manifest** (built in `src/plotterext.ts`; `version` from `package.json`):
+
+```jsonc
+{
+  "signalk-tides": {
+    "name": "Tides",
+    "description": "Tide-curve widget for the vessel's position, powered by Neaps.",
+    "version": "<package.json version>",
+    "apiVersion": "1",
+    "requires": ["widgets"],
+    "optional": ["units", "panels.iframe", "map"],
+    "widgets": [
+      { "id": "graph", "title": "Tide Cycle (Advanced)", "type": "iframe",
+        "url": "/plotterext/signalk-tides/graph.html", "size": "2x1",
+        "configPanel": "graph-config", "lifecycle": "whileEnabled" }
+    ],
+    "panels": [
+      { "id": "graph-config", "title": "Tide Cycle Settings", "type": "iframe",
+        "url": "/plotterext/signalk-tides/config.html", "lifecycle": "onOpen" }
+    ]
+  }
+}
+```
+
+Manifest key = package name `signalk-tides`; the SK plugin **id** is `tides`.
+
+### 3b. Time window
+
+The config panel picks how much of the forecast the graph shows. Kept short so
+the curve stays legible in a 2×1 tile (7 days crams the extreme labels into an
+unreadable smear):
+
+| value | span |
+|-------|------|
+| `12h` | 12 hours |
+| `24h` | 1 day (default) |
+| `48h` | 2 days |
+| `72h` | 3 days |
+
+Stored per instance as `{ "window": "24h" }`; the panel writes it, the widget
+follows `state.changed` and re‑requests the timeline for the new span.
+
+### 3c. Location mode
+
+`{ "locationMode": "vessel" | "chart" }` (default `vessel`).
+
+- **`vessel`** — tides for the vessel's own station, via the server‑side
+  `vessel/default` alias (the plugin's middleware resolves it to the configured
+  or nearest station). Unchanged from the webapp.
+- **`chart`** — tides for whatever point is centred in the host's chart. The
+  widget queries Neaps by `{ latitude, longitude }` and re‑queries only when the
+  rounded centre (~1 km) changes. It follows the viewport with the **`map.view`
+  event** (chart panned/zoomed): responsive, one update per settled view. It
+  reads `map.getView` once for the starting view. Chart mode is offered in the
+  config panel **only** when the host advertises the `map` capability, and
+  degrades to vessel tides when `map` is absent or before the first read.
+
+  `map.view` was added to the API alongside **Freeboard‑SK v3.1**; on older hosts
+  that expose `map` but not the event, the widget falls back to a slow
+  `map.getView` poll (stopped as soon as a real `map.view` event arrives).
+
+The existing Neaps middleware already honours explicit lat/lon queries (it only
+injects the vessel position when lat/lon are *absent*), so chart‑follow needs
+**no server change**.
+
+### 3d. Configuration panel — `graph-config` ("Tide Cycle Settings")
+
+An iframe panel (`lifecycle: onOpen`) the host opens on long‑press. It shows a
+**Time window** chooser always, and a **Tides for: Vessel position / Chart
+centre** chooser when the host supports `map`. It reads `state.get()` on load and
+writes the full config on each change (safe whether the host merges or replaces
+state). Every write emits `state.changed`, which the live widget follows.
+
+### 3e. Serving
+
+The widget build emits static iframe assets that our own registration serves via
+a public static route — **not** the webapp `public/` mount, **not** `/plugins/*`:
+
+```ts
+app.use('/plotterext/signalk-tides', express.static(WIDGET_BUILD_DIR)); // widgets/dist
+```
+
+This keeps the root Vite build, `index.html`, and the webapp mount untouched.
+
+---
+
+## 4. Footprint — what changes where
+
+**New browser code + build + tests under `widgets/`:**
+
+```text
+widgets/
+├── SPEC.md                      # this document (npm-ignored)
+├── vite.config.mts              # self-contained multi-entry build → widgets/dist
+├── web/
+│   ├── graph.html / graph.tsx           # 2×1 widget iframe entry
+│   ├── config.html / config.tsx         # config-panel iframe entry
+│   ├── TideGraphWidget.tsx              # static graph: TideGraphChart + data hooks
+│   ├── GraphConfig.tsx                  # window + location choosers (state.get/set)
+│   ├── host.ts                          # bus helper: connect, units, config, long-press, map poll
+│   └── widgets.css                      # translucent-dark theme + Tailwind/@neaps styles
+└── test/
+    └── TideGraphWidget.test.tsx         # browser: renders, static, no header/table, chart-follow
+```
+
+**Server registration lives in `src/` (not `widgets/server/`).** The plugin's
+flat `dist/index.js` output depends on `src/` being the sole TypeScript
+`rootDir`; pulling a `widgets/server` tree into that program would relocate the
+whole `dist/` layout. So the read‑only provider + manifest sit in
+`src/plotterext.ts` (compiled to `dist/plotterext.js`), and only the browser code
+lives under `widgets/`.
+
+**Edited existing files — minimal and enumerated:**
+
+1. **`src/index.ts`** — import `registerTideGraphWidget` and call it once in
+   `start()`. ~2 lines.
+2. **`src/plotterext.ts`** *(new)* — pure `buildManifest()` + `registerTideGraphWidget(app)`
+   (public static mount + read‑only `plotterExtensions` provider).
+3. **`test/plotterext.test.ts`** *(new)* — node tests for the manifest + provider.
+4. **`package.json`** — add runtime dep `signalk-plotterext-bus`; extend `build`
+   (`&& vite build --config widgets/vite.config.mts`). No version bump.
+5. **`tsconfig.app.json`** — add `widgets/web` + `widgets/test` to `include` so
+   the widget TSX is type‑checked by `tsc -b`.
+6. **`vitest.config.browser.ts`** — add `widgets/test/**/*.test.tsx` to `include`.
+7. **`.npmignore`** — ship the built `widgets/dist`; keep widget source out.
+8. **`.gitignore`** — ignore vitest browser artifacts (`__screenshots__`,
+   `.vitest-attachments`).
+
+No existing file is deleted/renamed; `app/`, `index.html`, `vite.config.mts`, the
+deltas, the Neaps API, and the `tides` resource are untouched.
+
+---
+
+## 5. Commands
+
+| Action | Command |
+|--------|---------|
+| Install | `npm install` |
+| Build (webapp **+ widget**) | `npm run build` |
+| Lint | `npm run lint` |
+| Node tests | `npm run test:node` |
+| Browser tests | `npm run test:browser` |
+| All tests | `npm test` |
+
+---
+
+## 6. Code style & conventions
+
+- **TypeScript** per the repo's strict `tsconfig.*`; `npm run lint` clean.
+- **React 19** + hooks, mirroring `app/App.tsx`. Reuse `@neaps/react`
+  components/hooks — do not reimplement tide math or the chart.
+- **Tailwind v4** + `@neaps/react` theme in `widgets.css` (the widget build runs
+  Tailwind and `@source`s the neaps dist, matching `app/App.css`).
+- Widgets are **guests on someone else's chart:** responsive, transparent
+  background, static (no navigation / `window.open` / modal), never block the UI
+  thread.
+- Recoverable failures (host lacks a capability, bus silent, no forecast yet) →
+  `console.warn` + graceful fallback, never `console.error` or a thrown crash.
+- Read‑only provider: `setResource`/`deleteResource` throw.
+- Keep `buildManifest()` a **pure**, testable function.
+
+---
+
+## 7. Testing
+
+- **`test/plotterext.test.ts`** (node) — one `plotterExtensions` provider;
+  `listResources()` → `{ "signalk-tides": manifest }`; `apiVersion "1"`,
+  `requires` includes `widgets`; **one** widget `graph` (2×1), `type iframe`, url
+  under `/plotterext/signalk-tides/`, `configPanel: "graph-config"`; one panel
+  `graph-config`; read‑only rejects; assets served on a public (non‑`/plugins`)
+  route.
+- **`widgets/test/TideGraphWidget.test.tsx`** (browser) — with the host bus mocked
+  and Neaps fetched via the dev proxy, the widget mounts and renders the graph
+  (an `svg`) **without** a header or table and **without** console errors/warnings;
+  a second case exercises chart‑follow (`map.getView` + location query) and the
+  station‑name caption.
+
+CI (`.github/workflows/ci.yml`) stays unchanged and green.
+
+---
+
+## 8. Boundaries
+
+**Always**
+- Keep the change **additive** and the footprint **minimal**.
+- Serve assets from a **public**, self‑mounted route
+  (`/plotterext/signalk-tides/…`), never `/plugins/*` or the webapp build.
+- Credit Neaps / openwaters in the PR description; keep the tone deferential.
+- Add tests for new behaviour.
+
+**Never**
+- **Bump the package version** — the maintainer owns versioning.
+- Modify existing `environment.tide.*` deltas, the Neaps API shape, the `tides`
+  resource, or the webapp.
+- Add server‑side runtime deps for the widget, or block read‑only users.
+
+### PR workflow (contributor → upstream)
+
+1. Sync `main` with `upstream/main`; branch off it.
+2. Implement + test locally; one logical change; **no version bump**.
+3. Open an **origin stand‑in PR first** (on the fork) so CodeRabbit reviews from
+   the contributor's account; address findings.
+4. Open the PR into `openwatersio:main` with a Conventional‑Commits title, e.g.
+   `feat(widgets): add Neaps-powered tide-graph widget for plotter-extension hosts`.
+   Credit Neaps and link the Plotter Extensions API; attach a screenshot.
+5. `widgets/SPEC.md` is npm‑ignored regardless; decide with the maintainer whether
+   it ships in the tree or is dropped.

--- a/widgets/test/TideGraphWidget.test.tsx
+++ b/widgets/test/TideGraphWidget.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// Fake host bus: answers units.get, map.getView, and the persisted config so
+// the widget resolves without the real postMessage handshake. This mirrors a
+// conforming host — the widget's tide data still comes from the (dev-proxied)
+// Neaps API, exactly as in production. Individual tests tune state.get to pick
+// the location mode.
+const fakeClient = {
+  hasCapability: () => true,
+  call: vi.fn(async (method: string) => {
+    if (method === "units.get") return { units: { depth: "foot" } };
+    // San Francisco Bay, [lon, lat] — same area as the dev server's mock vessel.
+    if (method === "map.getView") return { center: [-122.4194, 37.7749] };
+    return undefined;
+  }),
+  state: {
+    get: vi.fn(async (): Promise<Record<string, unknown>> => ({ window: "24h" })),
+    set: vi.fn(async () => {}),
+  },
+  subscribe: vi.fn(async () => async () => {}),
+  close: vi.fn(),
+};
+
+vi.mock("signalk-plotterext-bus/extension", () => ({
+  connectExtension: vi.fn(async () => fakeClient),
+}));
+
+// Imported after the mock is registered.
+const { TideGraphWidget } = await import("../web/TideGraphWidget");
+
+describe("TideGraphWidget", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fakeClient.state.get.mockResolvedValue({ window: "24h" });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("renders the tide graph, without a header or table, and without errors", async () => {
+    const { container } = render(<TideGraphWidget />);
+
+    // The graph-only component renders an SVG chart from real Neaps data.
+    await waitFor(() => expect(container.querySelector("svg")).not.toBeNull(), {
+      timeout: 10_000,
+    });
+
+    // Graph-only: no TideTable and no station-name heading (TideStationHeader).
+    expect(screen.queryByRole("table")).toBeNull();
+    expect(screen.queryByRole("heading")).toBeNull();
+
+    // The resolved station's name is shown in the corner.
+    await waitFor(() =>
+      expect(
+        container.querySelector(".tide-graph-station")?.textContent?.trim(),
+      ).toBeTruthy(),
+    );
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it("follows the chart centre when in chart-location mode", async () => {
+    fakeClient.state.get.mockResolvedValue({
+      window: "24h",
+      locationMode: "chart",
+    });
+
+    const { container } = render(<TideGraphWidget />);
+
+    await waitFor(() => expect(container.querySelector("svg")).not.toBeNull(), {
+      timeout: 10_000,
+    });
+
+    // Chart-follow reads the starting view via map.getView and subscribes to
+    // the map.view viewport event to track pan/zoom.
+    expect(fakeClient.call).toHaveBeenCalledWith("map.getView");
+    expect(fakeClient.subscribe).toHaveBeenCalledWith(
+      ["map.view"],
+      expect.any(Function),
+    );
+    // ...and the graph still renders cleanly from the location-based query.
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/widgets/test/TideGraphWidget.test.tsx
+++ b/widgets/test/TideGraphWidget.test.tsx
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+// The real page (graph.html -> graph.tsx) loads this; pull it in so styling
+// behaviour — e.g. the repositioned readout — is exercised as it ships.
+import "../web/widgets.css";
 
 // Fake host bus: answers units.get, map.getView, and the persisted config so
 // the widget resolves without the real postMessage handshake. This mirrors a
@@ -63,6 +66,20 @@ describe("TideGraphWidget", () => {
         container.querySelector(".tide-graph-station")?.textContent?.trim(),
       ).toBeTruthy(),
     );
+
+    // The current time/level readout is pushed off centre to the bottom edge.
+    // Guards the CSS hook into the chart's internal markup: if @neaps/react
+    // restructures that group, the selector silently stops matching and the
+    // readout drifts back over the curve.
+    const fill = container.querySelector<HTMLElement>(".tide-graph-fill");
+    expect(fill?.style.getPropertyValue("--tide-readout-shift")).toMatch(
+      /^\d+(\.\d+)?px$/,
+    );
+    const readoutBox = container.querySelector(
+      '.tide-graph-svg g[pointer-events="none"] > rect',
+    );
+    expect(readoutBox).not.toBeNull();
+    expect(getComputedStyle(readoutBox!).transform).not.toBe("none");
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
     expect(consoleWarnSpy).not.toHaveBeenCalled();

--- a/widgets/vite.config.mts
+++ b/widgets/vite.config.mts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Self-contained build for the Plotter Extensions widget iframes (web/) →
+// widgets/dist. Kept separate from the webapp's vite.config.mts so the root
+// build, index.html, and the public/ mount stay untouched. The plugin serves
+// widgets/dist at /plotterext/signalk-tides/, so assets are referenced with a
+// relative base.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: resolve(here, "web"),
+  base: "./",
+  plugins: [tailwindcss(), react()],
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
+  build: {
+    outDir: resolve(here, "dist"),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        graph: resolve(here, "web/graph.html"),
+        config: resolve(here, "web/config.html"),
+      },
+    },
+  },
+});

--- a/widgets/web/GraphConfig.tsx
+++ b/widgets/web/GraphConfig.tsx
@@ -1,0 +1,116 @@
+// Configuration panel for the tide-graph widget: choose the graph's time
+// window and — on a host that exposes its chart view (`map` capability) —
+// whether the tides track the vessel or the charted area. Settings persist to
+// the target widget instance's host-side state; each save emits `state.changed`,
+// which the live widget follows to re-render. Opened by the host on long-press;
+// the same host dialog also carries the remove affordance.
+
+import { useEffect, useState } from "react";
+import {
+  connectHost,
+  hasCapability,
+  readConfig,
+  DEFAULT_LOCATION_MODE,
+  DEFAULT_WINDOW,
+  LOCATION_OPTIONS,
+  WINDOW_OPTIONS,
+  type GraphWindow,
+  type LocationMode,
+} from "./host";
+import type { ExtensionClient } from "signalk-plotterext-bus/extension";
+
+export function GraphConfig() {
+  const [client, setClient] = useState<ExtensionClient | null>(null);
+  const [graphWindow, setGraphWindow] = useState<GraphWindow>(DEFAULT_WINDOW);
+  const [locationMode, setLocationMode] = useState<LocationMode>(
+    DEFAULT_LOCATION_MODE,
+  );
+  const [mapSupported, setMapSupported] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const c = await connectHost();
+      if (cancelled) {
+        c?.close();
+        return;
+      }
+      setClient(c);
+      setMapSupported(!!c && hasCapability(c, "map"));
+      const config = await readConfig(c);
+      if (cancelled) return;
+      setGraphWindow(config.graphWindow);
+      setLocationMode(config.locationMode);
+      setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist the whole config each time (safe whether the host merges or
+  // replaces state), so window and location mode never clobber each other.
+  const persist = (next: { window?: GraphWindow; locationMode?: LocationMode }) => {
+    const values = { window: graphWindow, locationMode, ...next };
+    client?.state
+      .set(values)
+      .catch((err) => console.warn("tide-graph config: state.set failed", err));
+  };
+
+  return (
+    <div className="tide-config">
+      <label className="tide-config-label" htmlFor="tide-graph-window">
+        Time window
+      </label>
+      <select
+        id="tide-graph-window"
+        className="tide-config-select"
+        value={graphWindow}
+        disabled={!ready}
+        onChange={(e) => {
+          const value = e.target.value as GraphWindow;
+          setGraphWindow(value);
+          persist({ window: value });
+        }}
+      >
+        {WINDOW_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <p className="tide-config-hint">
+        How many days of the tide forecast the graph shows.
+      </p>
+
+      {mapSupported && (
+        <>
+          <label className="tide-config-label" htmlFor="tide-graph-location">
+            Tides for
+          </label>
+          <select
+            id="tide-graph-location"
+            className="tide-config-select"
+            value={locationMode}
+            disabled={!ready}
+            onChange={(e) => {
+              const value = e.target.value as LocationMode;
+              setLocationMode(value);
+              persist({ locationMode: value });
+            }}
+          >
+            {LOCATION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <p className="tide-config-hint">
+            Show tides for the vessel, or for wherever the chart is centred.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/widgets/web/GraphConfig.tsx
+++ b/widgets/web/GraphConfig.tsx
@@ -30,12 +30,14 @@ export function GraphConfig() {
 
   useEffect(() => {
     let cancelled = false;
+    let established: ExtensionClient | null = null;
     (async () => {
       const c = await connectHost();
       if (cancelled) {
         c?.close();
         return;
       }
+      established = c;
       setClient(c);
       setMapSupported(!!c && hasCapability(c, "map"));
       const config = await readConfig(c);
@@ -46,6 +48,9 @@ export function GraphConfig() {
     })();
     return () => {
       cancelled = true;
+      // The panel is opened and dismissed repeatedly; close its connection so
+      // bus ports don't accumulate across openings.
+      established?.close();
     };
   }, []);
 

--- a/widgets/web/TideGraphWidget.tsx
+++ b/widgets/web/TideGraphWidget.tsx
@@ -1,0 +1,171 @@
+// The 2x1 "Tide Cycle (Advanced)" widget: the same multi-day harmonic curve the
+// webapp draws, but static — a widget is a guest on the chart, not an app, so
+// there is no scrolling, no "Now" button, and no tooltip. We compose the
+// low-level static pieces @neaps/react exports (the pure <TideGraphChart> SVG
+// plus the timeline/extremes data hooks) instead of the interactive <TideGraph>
+// wrapper. Data comes from the plugin's own Neaps API over same-origin REST —
+// exactly the path app/App.tsx uses — so this is real harmonic fidelity.
+
+import {
+  NeapsProvider,
+  TideGraphChart,
+  useContainerSize,
+  useCurrentLevel,
+  useExtremes,
+  useTimeline,
+  type Extreme,
+  type TimelineEntry,
+  type Units,
+  type UseTimelineParams,
+} from "@neaps/react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  WINDOW_DAYS,
+  useTideGraphHost,
+  type GraphWindow,
+  type LocationMode,
+  type MapCenter,
+} from "./host";
+
+// The server-side `vessel/default` alias: the plugin's middleware resolves it
+// (via a 303 redirect) to the configured station, or the one nearest the
+// vessel's position. Same alias the webapp uses (app/hooks/useStationId.ts).
+const VESSEL_STATION_ID = "vessel/default";
+const { VITE_SIGNALK_URL = window.location.toString() } = import.meta.env;
+const API_BASE_URL = new URL("/signalk/v2/api", VITE_SIGNALK_URL).toString();
+
+const MIN_GRAPH_HEIGHT = 72;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+// A little past-time so "now" isn't pinned hard against the left edge.
+const LOOKBACK_MS = HOUR_MS;
+
+const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const EMPTY_TIMELINE: TimelineEntry[] = [];
+const EMPTY_EXTREMES: Extreme[] = [];
+const NOOP = () => {};
+
+function hourBucketNow() {
+  return Math.floor((Date.now() - LOOKBACK_MS) / HOUR_MS);
+}
+
+// Forecast range floored to the hour, so the query key (and cache) stays stable
+// between renders — but it creeps forward as real time advances so a widget left
+// running for days doesn't freeze at its mount time. A once-a-minute tick only
+// bumps state when the hour bucket actually changes (i.e. at most hourly), so
+// the range moves without churning the cache every minute. The "now" marker
+// still tracks real time continuously via useCurrentLevel.
+function useForecastRange(days: number) {
+  const [bucket, setBucket] = useState(hourBucketNow);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = hourBucketNow();
+      setBucket((prev) => (prev === next ? prev : next));
+    }, 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return useMemo(() => {
+    const startMs = bucket * HOUR_MS;
+    return {
+      start: new Date(startMs).toISOString(),
+      end: new Date(startMs + LOOKBACK_MS + days * DAY_MS).toISOString(),
+    };
+  }, [bucket, days]);
+}
+
+function StaticGraph({
+  graphWindow,
+  locationMode,
+  mapCenter,
+  units,
+}: {
+  graphWindow: GraphWindow;
+  locationMode: LocationMode;
+  mapCenter: MapCenter | null;
+  units: Units;
+}) {
+  const { ref, width, height } = useContainerSize();
+  const days = WINDOW_DAYS[graphWindow];
+  const { start, end } = useForecastRange(days);
+
+  // Follow the chart centre when asked and a centre is available; otherwise
+  // (vessel mode, or chart mode before the first map read) query the vessel's
+  // own station via the `vessel/default` alias.
+  const params: UseTimelineParams =
+    locationMode === "chart" && mapCenter
+      ? {
+          latitude: mapCenter.latitude,
+          longitude: mapCenter.longitude,
+          start,
+          end,
+        }
+      : { id: VESSEL_STATION_ID, start, end };
+
+  const timelineQuery = useTimeline(params);
+  const extremesQuery = useExtremes(params);
+
+  const timeline = timelineQuery.data?.timeline ?? EMPTY_TIMELINE;
+  const extremes = extremesQuery.data?.extremes ?? EMPTY_EXTREMES;
+  const station = timelineQuery.data?.station;
+  const currentLevel = useCurrentLevel(timeline);
+
+  const graphHeight = Math.max(MIN_GRAPH_HEIGHT, Math.round(height) || 0);
+  const hasData = width > 0 && timeline.length > 0;
+  const failed = timelineQuery.isError || extremesQuery.isError;
+
+  return (
+    <div ref={ref} className="tide-graph-fill">
+      {hasData ? (
+        <>
+          <TideGraphChart
+            timeline={timeline}
+            extremes={extremes}
+            timezone={station?.timezone ?? LOCAL_TZ}
+            units={units}
+            svgWidth={width}
+            height={graphHeight}
+            latitude={station?.latitude}
+            longitude={station?.longitude}
+            activeEntry={currentLevel ?? undefined}
+            onSelect={NOOP}
+            className="tide-graph-svg"
+          />
+          {station?.name && (
+            <div className="tide-graph-station">{station.name}</div>
+          )}
+        </>
+      ) : (
+        <div className="tide-graph-placeholder">
+          {failed ? "Tide data unavailable" : "Loading tide graph…"}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TideGraphWidget() {
+  // `units` feeds the Neaps request, so wait until the host has answered before
+  // mounting the provider — otherwise it fetches with the locale default and
+  // then refetches (the chart flips units) once the real preference resolves.
+  const { units, graphWindow, locationMode, mapCenter, ready } =
+    useTideGraphHost();
+
+  return (
+    <div className="tide-graph-root">
+      {ready ? (
+        <NeapsProvider baseUrl={API_BASE_URL} units={units}>
+          <StaticGraph
+            graphWindow={graphWindow}
+            locationMode={locationMode}
+            mapCenter={mapCenter}
+            units={units}
+          />
+        </NeapsProvider>
+      ) : (
+        <div className="tide-graph-placeholder">Loading tide graph…</div>
+      )}
+    </div>
+  );
+}

--- a/widgets/web/TideGraphWidget.tsx
+++ b/widgets/web/TideGraphWidget.tsx
@@ -112,7 +112,10 @@ function StaticGraph({
   const currentLevel = useCurrentLevel(timeline);
 
   const graphHeight = Math.max(MIN_GRAPH_HEIGHT, Math.round(height) || 0);
-  const hasData = width > 0 && timeline.length > 0;
+  // Both halves are required: the curve without its high/low markers is a
+  // misleading partial chart, so a failed extremes query is "unavailable", not
+  // a graph to draw.
+  const hasData = width > 0 && timeline.length > 0 && extremes.length > 0;
   const failed = timelineQuery.isError || extremesQuery.isError;
 
   return (

--- a/widgets/web/TideGraphWidget.tsx
+++ b/widgets/web/TideGraphWidget.tsx
@@ -18,7 +18,7 @@ import {
   type Units,
   type UseTimelineParams,
 } from "@neaps/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import {
   WINDOW_DAYS,
   useTideGraphHost,
@@ -39,6 +39,28 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 // A little past-time so "now" isn't pinned hard against the left edge.
 const LOOKBACK_MS = HOUR_MS;
+
+// TideGraphChart draws the current time/level readout centred vertically
+// (`labelY = innerH / 2`), which in a short 2x1 tile sits right on top of the
+// curve. There is no prop for it, so we shift just that label down via CSS (see
+// `--tide-readout-shift` in widgets.css) to sit near the bottom edge instead.
+// These mirror the chart's own layout constants; if they drift, the readout is
+// merely offset differently — nothing breaks.
+const CHART_MARGIN_TOP = 65;
+const CHART_MARGIN_BOTTOM = 40;
+const READOUT_HALF_HEIGHT = 18;
+const READOUT_BOTTOM_GAP = 3;
+
+/** How far to push the readout down so it clears the bottom edge by 3px. */
+function readoutShift(graphHeight: number): number {
+  const innerH = Math.max(
+    0,
+    graphHeight - CHART_MARGIN_TOP - CHART_MARGIN_BOTTOM,
+  );
+  const target =
+    innerH + CHART_MARGIN_BOTTOM - READOUT_BOTTOM_GAP - READOUT_HALF_HEIGHT;
+  return Math.max(0, target - innerH / 2);
+}
 
 const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
 const EMPTY_TIMELINE: TimelineEntry[] = [];
@@ -119,7 +141,15 @@ function StaticGraph({
   const failed = timelineQuery.isError || extremesQuery.isError;
 
   return (
-    <div ref={ref} className="tide-graph-fill">
+    <div
+      ref={ref}
+      className="tide-graph-fill"
+      style={
+        {
+          "--tide-readout-shift": `${readoutShift(graphHeight)}px`,
+        } as CSSProperties
+      }
+    >
       {hasData ? (
         <>
           <TideGraphChart

--- a/widgets/web/config.html
+++ b/widgets/web/config.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tide Cycle Settings</title>
+  </head>
+  <body class="tide-panel">
+    <div id="root"></div>
+    <script type="module" src="./config.tsx"></script>
+  </body>
+</html>

--- a/widgets/web/config.tsx
+++ b/widgets/web/config.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { GraphConfig } from "./GraphConfig";
+import "./widgets.css";
+
+createRoot(document.getElementById("root")!).render(<GraphConfig />);

--- a/widgets/web/graph.html
+++ b/widgets/web/graph.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tide Cycle (Advanced)</title>
+  </head>
+  <body class="tide-widget">
+    <div id="root"></div>
+    <script type="module" src="./graph.tsx"></script>
+  </body>
+</html>

--- a/widgets/web/graph.tsx
+++ b/widgets/web/graph.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { TideGraphWidget } from "./TideGraphWidget";
+import "./widgets.css";
+
+createRoot(document.getElementById("root")!).render(<TideGraphWidget />);

--- a/widgets/web/host.ts
+++ b/widgets/web/host.ts
@@ -1,0 +1,379 @@
+// Thin Plotter Extensions host helpers for the tide-graph widget and its config
+// panel. The widget is a guest inside a host iframe: it connects to the host
+// over the JSON-RPC bus for the display-unit preference (`units.get`), its
+// per-instance config (the graph window, via `state`), and the press-and-hold
+// gesture that opens the config panel. Every host interaction is optional and
+// degrades quietly — a host missing a capability, or no host at all, leaves the
+// widget running with sensible defaults, never a thrown error.
+
+import { connectExtension, type ExtensionClient } from "signalk-plotterext-bus/extension";
+import { getDefaultUnits, type Units } from "@neaps/react";
+import { useEffect, useState } from "react";
+
+// How much of the forecast the graph shows. Kept short (12h–3 days): the curve
+// stays legible in a 2x1 tile, and more just crowds the extreme labels into an
+// unreadable smear.
+export type GraphWindow = "12h" | "24h" | "48h" | "72h";
+
+export const DEFAULT_WINDOW: GraphWindow = "24h";
+
+export const WINDOW_OPTIONS: { value: GraphWindow; label: string }[] = [
+  { value: "12h", label: "12 hours" },
+  { value: "24h", label: "1 day" },
+  { value: "48h", label: "2 days" },
+  { value: "72h", label: "3 days" },
+];
+
+export const WINDOW_DAYS: Record<GraphWindow, number> = {
+  "12h": 0.5,
+  "24h": 1,
+  "48h": 2,
+  "72h": 3,
+};
+
+const WINDOW_VALUES = new Set<string>(Object.keys(WINDOW_DAYS));
+
+export function coerceWindow(value: unknown): GraphWindow {
+  return typeof value === "string" && WINDOW_VALUES.has(value)
+    ? (value as GraphWindow)
+    : DEFAULT_WINDOW;
+}
+
+// Which location's tides the graph shows: the vessel's position (default), or
+// whatever point is currently centred in the host's chart. Chart-follow needs
+// the host's `map` capability; it degrades to vessel when unavailable.
+export type LocationMode = "vessel" | "chart";
+
+export const DEFAULT_LOCATION_MODE: LocationMode = "vessel";
+
+export const LOCATION_OPTIONS: { value: LocationMode; label: string }[] = [
+  { value: "vessel", label: "Vessel position" },
+  { value: "chart", label: "Chart centre" },
+];
+
+export function coerceLocationMode(value: unknown): LocationMode {
+  return value === "chart" ? "chart" : DEFAULT_LOCATION_MODE;
+}
+
+export interface MapCenter {
+  latitude: number;
+  longitude: number;
+}
+
+export interface WidgetConfig {
+  graphWindow: GraphWindow;
+  locationMode: LocationMode;
+}
+
+const LONG_PRESS_MS = 1500;
+const CONNECT_TIMEOUT_MS = 4000;
+
+/**
+ * Connect to the host, tolerating the standalone case (opened outside a host,
+ * or a host that never answers): resolves to null after a short timeout rather
+ * than hanging. Recoverable — the caller falls back to defaults.
+ */
+export async function connectHost(): Promise<ExtensionClient | null> {
+  try {
+    // If the handshake resolves after the timeout, we've already returned null
+    // to the caller — close that late client so it (and its listeners/ports)
+    // doesn't leak for the life of the page.
+    let settled = false;
+    const connecting = connectExtension().then((client) => {
+      if (settled) client?.close();
+      return client;
+    });
+    const timeout = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), CONNECT_TIMEOUT_MS),
+    );
+    const result = await Promise.race([connecting, timeout]);
+    settled = true;
+    return result;
+  } catch (err) {
+    console.warn("tide-graph: host connect failed", err);
+    return null;
+  }
+}
+
+export function hasCapability(client: ExtensionClient, cap: string): boolean {
+  return typeof client.hasCapability !== "function" || client.hasCapability(cap);
+}
+
+function mapDepthUnit(depth: unknown): Units | null {
+  if (depth === "foot") return "feet";
+  if (depth === "m") return "meters";
+  return null;
+}
+
+/**
+ * Resolve the depth unit the graph should display in. Prefers the host's
+ * `units.get` (the host derives it from the server's Unit Preferences); falls
+ * back to the server's active preset over same-origin REST — the same source
+ * the webapp's useUnitPreferences hook reads — and finally the locale default.
+ */
+export async function resolveUnits(client: ExtensionClient | null): Promise<Units> {
+  const fallback = getDefaultUnits(navigator.language);
+
+  if (client && hasCapability(client, "units")) {
+    try {
+      const res = (await client.call("units.get")) as {
+        units?: { depth?: unknown };
+      };
+      const mapped = mapDepthUnit(res?.units?.depth);
+      if (mapped) return mapped;
+    } catch (err) {
+      console.warn("tide-graph: units.get failed", err);
+    }
+  }
+
+  try {
+    const res = await fetch("/signalk/v1/unitpreferences/active", {
+      credentials: "include",
+    });
+    if (res.ok) {
+      const body = (await res.json()) as {
+        categories?: { depth?: { targetUnit?: unknown } };
+      };
+      const mapped = mapDepthUnit(body?.categories?.depth?.targetUnit);
+      if (mapped) return mapped;
+    }
+  } catch (err) {
+    console.warn("tide-graph: unit preferences fetch failed", err);
+  }
+
+  return fallback;
+}
+
+/** Read this widget instance's persisted config (window + location mode). */
+export async function readConfig(
+  client: ExtensionClient | null,
+): Promise<WidgetConfig> {
+  const defaults: WidgetConfig = {
+    graphWindow: DEFAULT_WINDOW,
+    locationMode: DEFAULT_LOCATION_MODE,
+  };
+  if (!client) return defaults;
+  try {
+    const stored = await client.state.get(["window", "locationMode"]);
+    return {
+      graphWindow: coerceWindow(stored?.window),
+      locationMode: coerceLocationMode(stored?.locationMode),
+    };
+  } catch (err) {
+    console.warn("tide-graph: state.get failed", err);
+    return defaults;
+  }
+}
+
+// Rounded to ~0.01° (~1 km) so tiny pans don't churn the tide query key; the
+// nearest-station resolution is coarser than that anyway.
+const CENTER_PRECISION = 100;
+
+function roundCenter(c: MapCenter): MapCenter {
+  return {
+    latitude: Math.round(c.latitude * CENTER_PRECISION) / CENTER_PRECISION,
+    longitude: Math.round(c.longitude * CENTER_PRECISION) / CENTER_PRECISION,
+  };
+}
+
+/**
+ * Extract the chart centre from a map view payload (`map.getView` result or a
+ * `map.view` event — both carry the same `{ center, zoom, bounds }` shape). FSK
+ * gives `center` as `[lon, lat]`. Returns null on any unexpected shape.
+ */
+export function parseCenter(view: unknown): MapCenter | null {
+  const c = (view as { center?: unknown } | null)?.center;
+  if (
+    Array.isArray(c) &&
+    c.length >= 2 &&
+    typeof c[0] === "number" &&
+    typeof c[1] === "number"
+  ) {
+    return roundCenter({ longitude: c[0], latitude: c[1] });
+  }
+  return null;
+}
+
+/**
+ * Read the host chart's current centre via `map.getView` — used for the initial
+ * view and as the poll fallback on hosts without the `map.view` event. Returns
+ * null (and warns) on failure so the widget falls back to the vessel.
+ */
+export async function readMapCenter(
+  client: ExtensionClient,
+): Promise<MapCenter | null> {
+  try {
+    return parseCenter(await client.call("map.getView"));
+  } catch (err) {
+    console.warn("tide-graph: map.getView failed", err);
+    return null;
+  }
+}
+
+/**
+ * Detect a press-and-hold anywhere in the widget iframe and ask the host to
+ * open the config panel. Pointer events inside a sandboxed iframe are invisible
+ * to the host, so the gesture is recognised here. Returns a cleanup function.
+ */
+export function installLongPress(client: ExtensionClient): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const cancel = () => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  };
+  const start = () => {
+    cancel();
+    timer = setTimeout(() => {
+      client.call("ui.openConfigPanel").catch(() => {});
+    }, LONG_PRESS_MS);
+  };
+  window.addEventListener("pointerdown", start);
+  window.addEventListener("pointerup", cancel);
+  window.addEventListener("pointercancel", cancel);
+  window.addEventListener("pointerleave", cancel);
+  return () => {
+    cancel();
+    window.removeEventListener("pointerdown", start);
+    window.removeEventListener("pointerup", cancel);
+    window.removeEventListener("pointercancel", cancel);
+    window.removeEventListener("pointerleave", cancel);
+  };
+}
+
+export interface HostState {
+  units: Units;
+  graphWindow: GraphWindow;
+  locationMode: LocationMode;
+  /** Chart centre while following the map (location mode `chart`); else null. */
+  mapCenter: MapCenter | null;
+  ready: boolean;
+}
+
+// Fallback poll interval for older hosts that expose `map` but don't emit the
+// `map.view` event. Kept slow (the spec's guidance) — event-capable hosts stop
+// it after the first event.
+const MAP_FALLBACK_POLL_MS = 15000;
+
+/**
+ * React hook wiring the widget to its host: resolves units + config once
+ * connected, follows `state.changed` (config-panel saves) to re-read window and
+ * location mode live, installs the long-press gesture, and — while in
+ * chart-follow mode on a host with the `map` capability — tracks the charted
+ * area. Renders immediately with defaults and refines as the host answers.
+ */
+export function useTideGraphHost(): HostState {
+  const [client, setClient] = useState<ExtensionClient | null>(null);
+  const [core, setCore] = useState({
+    units: getDefaultUnits(navigator.language),
+    graphWindow: DEFAULT_WINDOW,
+    locationMode: DEFAULT_LOCATION_MODE,
+    ready: false,
+  });
+  const [mapCenter, setMapCenter] = useState<MapCenter | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let removeLongPress: (() => void) | null = null;
+    let unsubscribe: (() => Promise<void>) | null = null;
+
+    (async () => {
+      const connected = await connectHost();
+      if (cancelled) {
+        connected?.close();
+        return;
+      }
+
+      const [units, config] = await Promise.all([
+        resolveUnits(connected),
+        readConfig(connected),
+      ]);
+      if (cancelled) {
+        connected?.close();
+        return;
+      }
+      setCore({ units, ...config, ready: true });
+      setClient(connected);
+
+      if (!connected) return;
+      removeLongPress = installLongPress(connected);
+
+      try {
+        unsubscribe = await connected.subscribe(["state.changed"], () => {
+          readConfig(connected)
+            .then((next) => {
+              if (!cancelled) setCore((prev) => ({ ...prev, ...next }));
+            })
+            .catch(() => {});
+        });
+      } catch (err) {
+        console.warn("tide-graph: state.changed subscribe failed", err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      removeLongPress?.();
+      unsubscribe?.().catch(() => {});
+    };
+  }, []);
+
+  // Track the chart centre while following the map on a capable host. Primary
+  // path is the `map.view` viewport event (FSK 3.1+): responsive, fires once per
+  // settled pan/zoom. The first event proves the host emits them, so the slow
+  // `map.getView` fallback poll — kept only for older hosts that expose `map`
+  // but not the event — is stopped.
+  useEffect(() => {
+    if (!client || core.locationMode !== "chart" || !hasCapability(client, "map")) {
+      setMapCenter(null);
+      return;
+    }
+    let cancelled = false;
+    let unsubscribe: (() => Promise<void>) | null = null;
+    let fallbackId: ReturnType<typeof setInterval> | null = null;
+
+    const apply = (c: MapCenter | null) => {
+      if (cancelled || !c) return;
+      setMapCenter((prev) =>
+        prev && prev.latitude === c.latitude && prev.longitude === c.longitude
+          ? prev
+          : c,
+      );
+    };
+    const stopFallback = () => {
+      if (fallbackId !== null) {
+        clearInterval(fallbackId);
+        fallbackId = null;
+      }
+    };
+
+    // Initial view.
+    readMapCenter(client).then(apply);
+
+    // Primary: follow viewport events.
+    client
+      .subscribe(["map.view"], (_name, params) => {
+        stopFallback();
+        apply(parseCenter(params));
+      })
+      .then((unsub) => {
+        if (cancelled) unsub().catch(() => {});
+        else unsubscribe = unsub;
+      })
+      .catch((err) =>
+        console.warn("tide-graph: map.view subscribe failed", err),
+      );
+
+    // Fallback poll for hosts without `map.view`; cancelled on the first event.
+    fallbackId = setInterval(() => {
+      readMapCenter(client).then(apply);
+    }, MAP_FALLBACK_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      stopFallback();
+      unsubscribe?.().catch(() => {});
+    };
+  }, [client, core.locationMode]);
+
+  return { ...core, mapCenter };
+}

--- a/widgets/web/host.ts
+++ b/widgets/web/host.ts
@@ -126,9 +126,15 @@ export async function resolveUnits(client: ExtensionClient | null): Promise<Unit
     }
   }
 
+  // Bounded: the widget blocks on this before it can render, so a server that
+  // accepts the connection but never answers must not wedge it on "Loading".
+  // An abort is just another failure — fall through to the locale default.
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), CONNECT_TIMEOUT_MS);
   try {
     const res = await fetch("/signalk/v1/unitpreferences/active", {
       credentials: "include",
+      signal: controller.signal,
     });
     if (res.ok) {
       const body = (await res.json()) as {
@@ -139,6 +145,8 @@ export async function resolveUnits(client: ExtensionClient | null): Promise<Unit
     }
   } catch (err) {
     console.warn("tide-graph: unit preferences fetch failed", err);
+  } finally {
+    clearTimeout(abortTimer);
   }
 
   return fallback;
@@ -275,6 +283,7 @@ export function useTideGraphHost(): HostState {
     let cancelled = false;
     let removeLongPress: (() => void) | null = null;
     let unsubscribe: (() => Promise<void>) | null = null;
+    let established: ExtensionClient | null = null;
 
     (async () => {
       const connected = await connectHost();
@@ -282,6 +291,7 @@ export function useTideGraphHost(): HostState {
         connected?.close();
         return;
       }
+      established = connected;
 
       const [units, config] = await Promise.all([
         resolveUnits(connected),
@@ -313,7 +323,11 @@ export function useTideGraphHost(): HostState {
     return () => {
       cancelled = true;
       removeLongPress?.();
-      unsubscribe?.().catch(() => {});
+      // Close the connection too, not just its listeners: a remounted widget
+      // would otherwise accumulate bus ports for the life of the page.
+      Promise.resolve(unsubscribe?.())
+        .catch(() => {})
+        .finally(() => established?.close());
     };
   }, []);
 

--- a/widgets/web/widgets.css
+++ b/widgets/web/widgets.css
@@ -62,6 +62,17 @@ body {
   pointer-events: none;
 }
 
+/* Move the current time/level readout off the vertical centre (where the chart
+ * hard-codes it, obscuring the curve in a short 2x1 tile) down to just above the
+ * bottom edge. The chart's readout group is its only pointer-events="none"
+ * group; it holds the full-height "now" line plus the label's box and text, so
+ * only the box/text are shifted — moving the group would drag the line down
+ * too. Offset comes from the widget (see readoutShift in TideGraphWidget). */
+.tide-graph-svg g[pointer-events="none"] > rect,
+.tide-graph-svg g[pointer-events="none"] > text {
+  transform: translateY(var(--tide-readout-shift, 0));
+}
+
 .tide-graph-placeholder {
   margin: auto;
   padding: 0.5rem;

--- a/widgets/web/widgets.css
+++ b/widgets/web/widgets.css
@@ -1,0 +1,131 @@
+/* Translucent-dark theme for the tide-graph widget and its config panel. The
+ * widget is a guest on someone else's chart: transparent page, a subtle dark
+ * scrim behind the curve so it stays legible over both light and dark maps,
+ * no scrollbars, and it fills whatever frame the host gives it.
+ *
+ * Mirrors app/App.css: pull in Tailwind and @neaps/react's theme, and @source
+ * the neaps dist so the utility classes its components use are generated. */
+
+@import "tailwindcss";
+@import "@neaps/react/styles.css";
+@source "../../node_modules/@neaps/react/dist";
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  background: transparent;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  color: #f1f5f9;
+  overscroll-behavior: none;
+}
+
+#root {
+  height: 100%;
+}
+
+/* ---- Widget ---- */
+
+.tide-graph-root,
+.tide-graph-fill {
+  height: 100%;
+  width: 100%;
+}
+
+.tide-graph-root {
+  display: flex;
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+.tide-graph-fill {
+  position: relative;
+}
+
+/* The static chart is a display, not a control: no pointer interaction (no
+ * scroll, tooltip, or selection). Pointer events pass through to the window,
+ * where the long-press-to-configure gesture still listens. */
+.tide-graph-svg {
+  display: block;
+  pointer-events: none;
+}
+
+.tide-graph-placeholder {
+  margin: auto;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+/* Station name, pinned top-left in the chart's blank left/top margin. Clipped
+ * with an ellipsis and capped short of centre so it never runs into the date
+ * label the chart draws over each day (around local noon). */
+.tide-graph-station {
+  position: absolute;
+  top: 3px;
+  left: 6px;
+  max-width: 45%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: #cbd5e1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ---- Config panel ---- */
+
+.tide-panel {
+  background: transparent;
+}
+
+.tide-config {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  min-width: 12rem;
+}
+
+.tide-config-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.tide-config-select {
+  appearance: none;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.875rem;
+  color: #f1f5f9;
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid #334155;
+  border-radius: 6px;
+}
+
+.tide-config-select:disabled {
+  opacity: 0.6;
+}
+
+.tide-config-hint {
+  margin: 0;
+  font-size: 0.6875rem;
+  line-height: 1.35;
+  color: #94a3b8;
+}


### PR DESCRIPTION
## What

Freeboard‑SK 3.0 was just released with the new **Plotter Extensions API** — a host‑agnostic way for a Signal K plugin to contribute UI directly onto the chart plotter. This PR uses it to add one optional **2×1 "Tide Cycle (Advanced)"** widget: any Plotter Extensions host (Freeboard‑SK and others) can place `signalk-tides`' multi‑day harmonic curve right on the chart, powered by Neaps.

<img width="800" height="501" alt="tide-cycle-advanced" src="https://github.com/user-attachments/assets/577e2895-a71a-4377-adf2-de239312a71c" />

## Why

A demonstration of the [Plotter Extensions API](https://github.com/SignalK/freeboard-sk/blob/master/docs/api/plotter-extensions-api.md) and a spotlight on Neaps — a small template other data plugins can copy to publish a chart‑plotter widget alongside their service. Purely additive: the webapp, deltas, Neaps API, and the `tides` resource are untouched, and there is **no version bump**.

## How

- A read‑only `plotterExtensions` resource provider plus a public static route (`/plotterext/signalk-tides/…`) serving sandboxed iframe assets. New browser code lives under `widgets/`; registration is in `src/plotterext.ts` (kept in `src/` so the flat `dist/` layout is unchanged).
- The graph is **static** — composed from `@neaps/react`'s `TideGraphChart` + `useTimeline`/`useExtremes` hooks rather than the interactive `<TideGraph>` wrapper — because a widget is a guest on the chart (no scroll, no tooltip).
- Config panel: **time window** (12h / 1 / 2 / 3 days) and, on hosts advertising the `map` capability, an optional **follow-the-charted-area** mode (reads `map.getView`; falls back to the vessel's station when unavailable).
- Honours the host's depth‑unit preference; shows the resolved tide‑station name.

## Test plan

- [x] `npm run build` (webapp + widget)
- [x] `npm run lint`
- [x] `npm test` (node + browser)
- [x] Verified live in Freeboard‑SK — vessel and chart‑follow, all four windows

---

Tides powered by **[Neaps](https://openwaters.io)** (openwaters.io).
